### PR TITLE
feat(ch13.1): red-black logarithmic height theorem (CLRS Lemma 13.1) (#7)

### DIFF
--- a/CLRSLean/Chapter_13/Section_13_1_Red_Black_Trees.lean
+++ b/CLRSLean/Chapter_13/Section_13_1_Red_Black_Trees.lean
@@ -43,11 +43,13 @@ Main results:
   the original black height.
 - Theorem {lit}`RBTree.blackHeight_insert`: insertion either keeps the black
   height or increases it by one.
+- Theorem {lit}`RBTree.height_log_bound`: **CLRS Lemma 13.1** — a red-black
+  tree with {lit}`n` internal nodes has height at most {lit}`2 log₂(n + 1)`.
 
 Remaining gaps:
 
-- The executable {lit}`RB-DELETE` and {lit}`RB-DELETE-FIXUP` algorithms, and the
-  logarithmic-height theorem, remain future work.
+- The executable {lit}`RB-DELETE` and {lit}`RB-DELETE-FIXUP` algorithms remain
+  future work.
 -/
 
 namespace CLRS
@@ -1104,6 +1106,149 @@ theorem blackHeight_insert {x : Nat} {t : RBTree} (h : RedBlackShape t) :
   · right
     rw [insert]
     rw [blackHeight_repaintRoot_black_increases hRoot, hHeight]
+/-! ## Logarithmic height bound (CLRS Lemma 13.1)
+
+A red-black tree with {lit}`n` internal nodes has height at most
+{lit}`2 log₂(n + 1)`.  The proof follows the textbook decomposition:
+
+1. Every subtree rooted at {lit}`x` has at least {lit}`2^{bh(x)} - 1` internal
+   nodes (Lemma A).
+2. The height of a no-red-red tree is at most twice its black height (Lemma B).
+3. From (1), {lit}`bh ≤ log₂(n + 1)`; from (2), {lit}`h ≤ 2·bh`.
+
+Main results:
+
+- Theorem {lit}`height_le_two_mul_blackHeight_of_RedBlackShape`: height ≤ 2·bh
+  for any red-black-shaped tree.
+- Theorem {lit}`size_add_one_ge_two_pow_blackHeight`: size + 1 ≥ 2^bh for any
+  balanced-black-height tree.
+- Theorem {lit}`height_log_bound`: the full CLRS Lemma 13.1 bound. -/
+
+/-- The height (maximum depth) of a red-black tree: the longest path from the
+root to an empty leaf, counting edges.  Empty tree height is 0. -/
+def height : RBTree → Nat
+  | .empty => 0
+  | .node _ l _ r => 1 + max l.height r.height
+
+/-- The internal node count of a red-black tree. -/
+def size : RBTree → Nat
+  | .empty => 0
+  | .node _ l _ r => 1 + l.size + r.size
+
+/-- **Lemma A.**  A tree with balanced black heights has at least {lit}`2^{bh} - 1`
+internal nodes.  Formalised as {lit}`size t + 1 ≥ 2 ^ blackHeight t`. -/
+theorem size_add_one_ge_two_pow_blackHeight (t : RBTree)
+    (hBal : BalancedBlackHeight t) : size t + 1 ≥ 2 ^ blackHeight t := by
+  induction t with
+  | empty => simp [size, blackHeight]
+  | node c l k r ihl ihr =>
+    simp only [BalancedBlackHeight] at hBal
+    rcases hBal with ⟨hlBal, hrBal, heq⟩
+    have ihl' : size l + 1 ≥ 2 ^ blackHeight l := ihl hlBal
+    have ihr' : size r + 1 ≥ 2 ^ blackHeight l := by
+      rw [heq]; exact ihr hrBal
+    simp only [size]
+    have h_sum : 1 + size l + size r + 1 = (size l + 1) + (size r + 1) := by omega
+    rw [h_sum]
+    rw [blackHeight]
+    have h_pow_succ : 2 ^ blackHeight l + 2 ^ blackHeight l = 2 ^ (blackHeight l + 1) := by
+      rw [← two_mul, mul_comm, ← Nat.pow_succ 2 (blackHeight l)]
+    by_cases hc : c = Color.black
+    · subst hc
+      have h_if : (if Color.black = Color.black then (1 : ℕ) else 0) = 1 := by simp
+      rw [h_if]
+      rw [← h_pow_succ]
+      exact add_le_add ihl' ihr'
+    · -- c ≠ black
+      rw [if_neg hc]
+      have h_add : (size l + 1) + (size r + 1) ≥ size l + 1 := Nat.le_add_right _ _
+      exact Nat.le_trans ihl' h_add
+
+/-- **Boolean root-black test**, for use in propositions that need decidability. -/
+def rootBlack : RBTree → Bool
+  | .empty => true
+  | .node c _ _ _ => c = Color.black
+
+/-- The {lit}`Bool` version agrees with the {lit}`Prop` version. -/
+theorem rootBlack_eq_RootBlack (t : RBTree) : rootBlack t = true ↔ RootBlack t := by
+  cases t <;> simp [rootBlack, RootBlack]
+
+/-- **Lemma B (strengthened induction hypothesis).**  For a tree with
+{lit}`NoRedRed` and {lit}`BalancedBlackHeight`, the height is bounded by twice
+the black height plus a root-color adjustment term.  Uses a {lit}`Bool` version
+of the condition to avoid decidability issues. -/
+theorem height_le_two_mul_blackHeight_add_adj (t : RBTree)
+    (hRed : NoRedRed t) (hBal : BalancedBlackHeight t) :
+    height t ≤ 2 * blackHeight t + (if rootBlack t then 0 else 1) := by
+  induction t with
+  | empty => simp [height, blackHeight, rootBlack]
+  | node c l k r ihl ihr =>
+    simp only [NoRedRed] at hRed
+    rcases hRed with ⟨hlRed, hrRed, hRedCond⟩
+    simp only [BalancedBlackHeight] at hBal
+    rcases hBal with ⟨hlBal, hrBal, heq⟩
+    have ihl' := ihl hlRed hlBal
+    have ihr' := ihr hrRed hrBal
+    simp only [height, blackHeight]
+    have hmax : max (height l) (height r) ≤ 2 * blackHeight l + 1 := by
+      have hL : height l ≤ 2 * blackHeight l + (if rootBlack l then 0 else 1) := ihl'
+      have hR : height r ≤ 2 * blackHeight r + (if rootBlack r then 0 else 1) := ihr'
+      have hR' : height r ≤ 2 * blackHeight l + (if rootBlack r then 0 else 1) := by
+        rw [heq]; exact hR
+      have adjL : (if rootBlack l then 0 else 1 : ℕ) ≤ 1 := by split <;> omega
+      have adjR : (if rootBlack r then 0 else 1 : ℕ) ≤ 1 := by split <;> omega
+      apply max_le
+      · omega
+      · omega
+    have hrhs : 1 + max (height l) (height r) ≤ 1 + (2 * blackHeight l + 1) := by omega
+    by_cases hc : c = Color.black
+    · subst hc
+      simp
+      convert Nat.add_le_add_right hmax 1 using 1
+      · simp [add_comm]
+      · calc
+          (2 * blackHeight l + 1) + 1 = 2 * blackHeight l + (1 + 1) := by rw [add_assoc]
+          _ = 2 * blackHeight l + 2 := by norm_num
+          _ = 2 * (blackHeight l + 1) := by rw [Nat.mul_succ]
+    · have hc_red : c = Color.red := by cases c <;> simp_all
+      subst hc_red
+      simp
+      have hmax_red : max (height l) (height r) ≤ 2 * blackHeight l := by
+        have hl_bound : height l ≤ 2 * blackHeight l := by
+          -- From ihl': height l ≤ 2*bl + (if rootBlack l then 0 else 1)
+          -- After subst, rootBlack l = true (from NoRedRed)
+          have hRoot_lb : rootBlack l = true :=
+            (rootBlack_eq_RootBlack l).mpr ((hRedCond rfl).1)
+          simp [hRoot_lb] at ihl'; omega
+        have hr_bound : height r ≤ 2 * blackHeight l := by
+          have hRoot_rb : rootBlack r = true :=
+            (rootBlack_eq_RootBlack r).mpr ((hRedCond rfl).2)
+          simp [hRoot_rb] at ihr'; omega
+        exact max_le hl_bound hr_bound
+      convert Nat.add_le_add_right hmax_red 1 using 1
+      · simp [add_comm]
+      · rfl
+
+/-- **Lemma B (public form).**  For any red-black-shaped tree, height ≤ 2·bh. -/
+theorem height_le_two_mul_blackHeight_of_RedBlackShape (t : RBTree)
+    (hShape : RedBlackShape t) : height t ≤ 2 * blackHeight t := by
+  obtain ⟨hRoot, hRed, hBal⟩ := hShape
+  have h := height_le_two_mul_blackHeight_add_adj t hRed hBal
+  have hRoot_b : rootBlack t = true := (rootBlack_eq_RootBlack t).mpr hRoot
+  rw [hRoot_b] at h
+  simpa using h
+
+/-- **CLRS Lemma 13.1.**  A red-black tree with {lit}`n` internal nodes has
+height at most {lit}`2 log₂ (n + 1)`. -/
+theorem height_log_bound (t : RBTree) (hShape : RedBlackShape t) :
+    height t ≤ 2 * Nat.log 2 (size t + 1) := by
+  have hBal : BalancedBlackHeight t := hShape.2.2
+  have hSize := size_add_one_ge_two_pow_blackHeight t hBal
+  have hHeight := height_le_two_mul_blackHeight_of_RedBlackShape t hShape
+  have hLog : blackHeight t ≤ Nat.log 2 (size t + 1) :=
+    Nat.le_log_of_pow_le (by omega) hSize
+  omega
+
 end RBTree
 
 end Chapter13

--- a/docs/proof-map.md
+++ b/docs/proof-map.md
@@ -1042,6 +1042,9 @@ BST interface.  It deliberately stops before mutable heap or RAM semantics.
   - `CLRS.Chapter13.RBTree.insertFixupLocal_leftRight_certificate`
   - `CLRS.Chapter13.RBTree.insertFixupLocal_rightLeft_certificate`
   - `CLRS.Chapter13.RBTree.insertFixupLocal_rightRight_certificate`
+  - `CLRS.Chapter13.RBTree.size_add_one_ge_two_pow_blackHeight` (Lemma A)
+  - `CLRS.Chapter13.RBTree.height_le_two_mul_blackHeight_of_RedBlackShape` (Lemma B)
+  - `CLRS.Chapter13.RBTree.height_log_bound` (**CLRS Lemma 13.1**)
 - Proof pattern: local colored-tree invariants, rotations, root recoloring,
   red-red rotation repair certificates, and four insertion-fixup local
   rotation/recoloring certificates.  Each insertion-fixup case separately
@@ -1049,7 +1052,10 @@ BST interface.  It deliberately stops before mutable heap or RAM semantics.
   red-black shape invariant from red-black-shaped fringe subtrees with matching
   black heights.  The `insertFixupLocal` dispatcher and certificate structure
   package those three facts behind one branch-indexed interface for a future
-  executable fixup.
+  executable fixup.  The logarithmic-height bound (CLRS Lemma 13.1) is proved by
+  the standard two-lemma decomposition: a balanced-black-height tree has at
+  least `2^bh - 1` internal nodes (Lemma A), and a no-red-red tree has height at
+  most twice its black height (Lemma B), combined via `Nat.log`.
 - Current gap: compose the local insertion-fixup certificates into executable
   `RB-INSERT`/`RB-INSERT-FIXUP`; full `RB-DELETE` and `RB-DELETE-FIXUP` are not
   mechanized

--- a/docs/proof-status-board.md
+++ b/docs/proof-status-board.md
@@ -34,7 +34,7 @@ missing core theorem groups.
 | 9 | Rank selection and executable median-of-medians correctness with linear recurrence wrapper | Randomized SELECT and concrete executable cost semantics |
 | 11 | Deterministic hash tables and finite-uniform bucket averages | Random key/hash-function model with independence |
 | 12 | Functional BST operations plus zipper-based parent navigation, transplant, and deletion equivalence | Imperative in-place pointer mutation and RAM refinement |
-| 13 | Executable red-black insertion and invariant proofs | Deletion/fixup and logarithmic height |
+| 13 | Executable red-black insertion, invariant proofs, and the logarithmic-height theorem (Lemma 13.1) | Deletion/fixup (`RB-DELETE`/`RB-DELETE-FIXUP`) |
 | 14 | Order-statistic augmentation, generic local augmentation, and interval-search correctness | Integration with red-black balancing and a final general augmentation interface |
 | 15 | Rod cutting, matrix chain, LCS, and optimal BST optimality with pure executable tables/reconstruction | Mutable-array/memoized refinement and RAM costs |
 | 17 | Aggregate/accounting/potential framework and represented examples | Mutable arrays, allocator costs, sharper table model |


### PR DESCRIPTION
Part of #7 — delivers the **logarithmic-height theorem (CLRS Lemma 13.1)**, the self-contained piece of #7 that depends only on the `RedBlackShape` invariant (not on the delete algorithm). `RB-DELETE` / `RB-DELETE-FIXUP` remain and can be a follow-up.

## Summary

Adds the classic red-black height bound to §13.1, proved by the standard two-lemma decomposition.

`lake build` clean (8681 jobs), **0 sorries**, **0 doc-role warnings**.

## What's proved (`namespace CLRS.Chapter13.RBTree`)

| Item | Meaning |
|------|---------|
| `height`, `size` | max-depth (edges) and internal-node-count functions |
| `size_add_one_ge_two_pow_blackHeight` | **Lemma A**: a `BalancedBlackHeight` tree has `size + 1 ≥ 2^bh` (≥ `2^bh - 1` internal nodes) |
| `rootBlack` + `rootBlack_eq_RootBlack` | a `Bool` mirror of `RootBlack`, to keep the adjustment term decidable in the induction |
| `height_le_two_mul_blackHeight_add_adj` / `_of_RedBlackShape` | **Lemma B**: a `NoRedRed` tree has `height ≤ 2·bh` (with a root-color adjustment in the IH) |
| `height_log_bound` | **CLRS Lemma 13.1**: `height t ≤ 2 * Nat.log 2 (size t + 1)` |

## Proof notes

- Lemma A: induction; a black root adds a black-height level (`2^bh + 2^bh = 2^(bh+1)`), a red root keeps `bh` and only grows the node count.
- Lemma B: the IH carries a `+ (if rootBlack then 0 else 1)` adjustment so a red parent (whose children must be black, from `NoRedRed`) tightens the child bound from `2·bh + 1` to `2·bh`.
- Combined via `Nat.le_log_of_pow_le`.

## Scope

Added to §13.1 (no new file). Deletion (`RB-DELETE` / `RB-DELETE-FIXUP` and its per-case certificates) is the remaining part of #7 and is a natural follow-up — the height theorem is orthogonal and complete on its own.

Docs synced: `proof-map.md` (§13.1 entry) and `proof-status-board.md` (Ch13 row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
