### PR TITLE
chore(ch9): clean up chapter closure and site preview

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,23 +57,12 @@ jobs:
       - name: Check generated HTML freshness
         run: python3 scripts/check_literate_html_freshness.py "${{ steps.build-site.outputs.path }}"
 
-      - name: Assemble _site
+      - name: Assemble optimized _site
         run: |
-          VERSO_OUT="${{ steps.build-site.outputs.path }}"
-          echo "Verso output: $VERSO_OUT"
-          rm -rf _site
-          mkdir -p _site
-          cp -r "$VERSO_OUT"/* _site/
-          cp docs/literate/clrs-literate.css _site/clrs-literate.css
-
-      - name: Optimize generated HTML
-        run: python3 scripts/optimize_literate_html.py _site
-
-      - name: Check rendered HTML
-        run: python3 scripts/check_literate_rendering.py _site
-
-      - name: Generate sitemap
-        run: python3 scripts/generate_sitemap.py _site --base-url "https://tanktechnology.github.io/CLRS-Lean/"
+          python3 scripts/prepare_literate_site.py \
+            "${{ steps.build-site.outputs.path }}" \
+            _site \
+            --base-url "https://tanktechnology.github.io/CLRS-Lean/"
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/CLRSLean/Chapter_09.lean
+++ b/CLRSLean/Chapter_09.lean
@@ -15,55 +15,23 @@ recursive median-of-medians SELECT has an end-to-end cost at most {lit}`100n`.
 
 ## Sections
 
-* 9.1 Minimum and maximum: {lit}`proved` for the pairwise simultaneous-extrema
-  algorithm.  Main results:
-  {lit}`CLRS.Chapter09.minMax?_correct` and
-  {lit}`CLRS.Chapter09.minMax?_comparisons_le`.
-* 9.2 Selection in expected linear time: rank correctness is proved for the
-  specification selector and pivot-style quickselect model.  The standard
-  uniform-pivot majorizing recurrence is linear, and a fresh-choice stochastic
-  execution is coupled pointwise to its larger-side argument.  Main results:
-  {lit}`CLRS.Chapter09.selectByRank?_mem`,
-  {lit}`CLRS.Chapter09.selectByRank?_rankCorrect`, and
-  {lit}`CLRS.Chapter09.selectByRank?_correct`;
-  {lit}`CLRS.Chapter09.quickSelect?_mem`,
-  {lit}`CLRS.Chapter09.quickSelect?_rankCorrect`, and
-  {lit}`CLRS.Chapter09.quickSelect?_correct`,
-  {lit}`CLRS.Chapter09.randomizedSelectMajorizer_bigO_linear`,
-  {lit}`CLRS.Chapter09.freshRandomizedSelectWithRanks?_correct`,
-  {lit}`CLRS.Chapter09.freshRandomizedSelectContinuationSize_le_subproblemSize`,
-  and
-  {lit}`CLRS.Chapter09.freshRandomizedSelectExpectedComparisons_linear_bound`.
-* 9.3 Selection in worst-case linear time: the pivot-parametric selector and
-  recursively pivoted executable selector are total and rank-correct, grouped
-  split-count bounds and the abstract linear recurrence are proved, and the
-  complete comparison cost includes every nested pivot construction.  Main results:
-  {lit}`CLRS.Chapter09.selectWithPivot?_correct`,
-  {lit}`CLRS.Chapter09.medianOfFive?_certificate`,
-  {lit}`CLRS.Chapter09.fullGroupsOfFive_medianGroupCertificates`,
-  {lit}`CLRS.Chapter09.fullGroupsOfFive_medianPivot_split_counts`,
-  {lit}`CLRS.Chapter09.fullGroupsOfFive_medianPivot_fullInput_split_counts`,
-  {lit}`CLRS.Chapter09.fullGroupsOfFive_medianPivot_partition_size_bound`,
-  {lit}`CLRS.Chapter09.selectRecurrence_linear_step`,
-  {lit}`CLRS.Chapter09.medianOfMediansPivot?_recursive_branch_size_bound`,
-  {lit}`CLRS.Chapter09.medianOfMediansPivot?_low_branch_linear_work_step`,
-  {lit}`CLRS.Chapter09.medianOfMediansPivot?_high_branch_linear_work_step`,
-  {lit}`CLRS.Chapter09.selectRecurrence_linear_induction`,
-  {lit}`CLRS.Chapter09.medianOfMedians_linear_bound`,
-  {lit}`CLRS.Chapter09.clrsSelectRecurrence_linear_bound`,
-  {lit}`CLRS.Chapter09.medianGroupCertificates_selectPivot_split_counts`,
-  {lit}`CLRS.Chapter09.medianOfMediansPivot?_partition_size_bound`, and
-  {lit}`CLRS.Chapter09.medianOfMediansSelect?_isSome_of_lt` and
-  {lit}`CLRS.Chapter09.medianOfMediansSelect?_correct`; the partition-path cost
-  semantics {lit}`CLRS.Chapter09.medianOfMediansPartitionPathCost` with its
-  explicit bound
-  {lit}`CLRS.Chapter09.medianOfMediansPartitionPathCost_linear_bound`, built on
-  the generic
-  {lit}`CLRS.Chapter09.selectCost_linear_bound`; and the recursive layer
-  {lit}`CLRS.Chapter09.recursiveMedianOfMediansPivot?_partition_size_bound`,
-  {lit}`CLRS.Chapter09.recursiveMedianOfMediansSelect?_isSome_of_lt`,
-  {lit}`CLRS.Chapter09.recursiveMedianOfMediansSelect?_correct`, and
-  {lit}`CLRS.Chapter09.recursiveMedianOfMediansComparisonCost_linear_bound`.
+* 9.1 proves simultaneous minimum/maximum correctness and the pairwise
+  comparison bound.
+* 9.2 proves duplicate-aware rank selection, pivot-style SELECT correctness,
+  and the fresh-choice randomized expected bound.
+* 9.3 proves recursive median-of-medians SELECT correctness and its complete
+  worst-case comparison bound.
+
+## Closure interface
+
+The chapter's main public results are
+{lit}`CLRS.Chapter09.minMax?_correct`,
+{lit}`CLRS.Chapter09.minMax?_comparisons_le`,
+{lit}`CLRS.Chapter09.freshRandomizedSelectWithRanks?_correct`,
+{lit}`CLRS.Chapter09.freshRandomizedSelectExpectedComparisons_linear_bound`,
+{lit}`CLRS.Chapter09.recursiveMedianOfMediansSelect?_correct`, and
+{lit}`CLRS.Chapter09.recursiveMedianOfMediansComparisonCost_linear_bound`.
+The proof map records the supporting theorem inventory.
 
 ## Completion boundary
 

--- a/CLRSLean/Chapter_09/Section_09_2_Select_By_Rank.lean
+++ b/CLRSLean/Chapter_09/Section_09_2_Select_By_Rank.lean
@@ -14,11 +14,12 @@ usual order-statistic way: if the selected value is {lit}`x`, then at most
 {lit}`k` elements are strictly smaller than {lit}`x`, and more than {lit}`k`
 elements are at most {lit}`x`.
 
-## Expected-time analysis
+## Randomized SELECT theorem page
 
 The uniform-pivot recurrence, fresh per-call stochastic execution, and CLRS
-Theorem 9.2 expected linear comparison bound are proved on a support page that
-remains available outside the main sidebar:
+Theorem 9.2 expected linear comparison bound are proved on the Section 9.2
+support page below.  It remains directly available without adding another row
+to the reader sidebar:
 
 * [Randomized SELECT Expected Time](CLRSLean/Chapter_09/Section_09_3_Deterministic_Select/Randomized_Select/)
 -/

--- a/CLRSLean/Chapter_09/Section_09_3_Deterministic_Select.lean
+++ b/CLRSLean/Chapter_09/Section_09_3_Deterministic_Select.lean
@@ -11,72 +11,20 @@ Section 9.2.
 
 Main results:
 
-* Theorem {lit}`selectWithPivot?_correct`: a pivot-parametric SELECT is rank
-  correct whenever the pivot rule returns members of the current list.
-* Theorem {lit}`medianOfFive?_certificate`: the median selected from a
-  five-element group has at least three elements below it weakly and at least
-  three elements above it weakly.
-* Theorems {lit}`medianGroupCertificates_leCount_lower_bound` and
-  {lit}`medianGroupCertificates_geCount_lower_bound`: a collection of certified
-  five-element groups contributes three original elements for every group
-  median on the corresponding side of a pivot.
-* Theorem {lit}`fullGroupsOfFive_medianPivot_split_counts`: the executable
-  full-grouping wrapper constructs the certificates and obtains the split
-  counts for a median of the group medians.
-* Theorem {lit}`fullGroupsOfFive_medianPivot_fullInput_split_counts`: the
-  grouped split counts lift to the original input list because the flattened
-  full groups are a sublist of the input.
-* Theorem {lit}`fullGroupsOfFive_medianPivot_partition_size_bound`: both
-  strict recursive branches around the pivot satisfy the familiar
-  {lit}`7n/10 + O(1)` CLRS size bound.
-* Theorem {lit}`selectRecurrence_linear_step`: a pure {lean}`Nat`
-  substitution step
-  for closing a linear envelope from one one-fifth median subproblem, one
-  {lit}`7n/10 + O(1)` strict branch, and local-work slack.
-* Theorem {lit}`medianOfMediansPivot?_recursive_branch_size_bound`: the
-  proved count bound specialized to the actual filtered recursive branch
-  lists.
-* Theorems {lit}`medianOfMediansPivot?_low_branch_linear_work_step` and
-  {lit}`medianOfMediansPivot?_high_branch_linear_work_step`: executable
-  branch wrappers that connect the median-of-medians pivot bound to the
-  linear-work recurrence step.
-* Theorem {lit}`deterministicSelect?_correct`: a deterministic median-pivot
-  instance is rank correct.
-* Theorem {lit}`selectRecurrence_linear_induction`: a threshold-parametric
-  strong induction that lifts {lit}`selectRecurrence_linear_step` to the full
-  recursion tree for any cost function satisfying the CLRS subproblem-size
-  bounds.
-* Theorem {lit}`medianOfMedians_linear_bound`: a concrete instantiation with
-  the standard median-of-medians branch sizes {lit}`n/5` and {lit}`(7n+12)/10`,
-  proving linear cost whenever the per-element work coefficient is bounded
-  relative to the overall constant.
-* Theorem {lit}`clrsSelectRecurrence_linear_bound`: a CLRS-facing name for the
-  same linear-time SELECT recurrence closure.
-* Definition {lit}`selectCostFuel` and wrapper {lit}`selectCost`: an executable
-  {lit}`Nat`-valued cost counter that mirrors the {lit}`selectWithPivotFuel?`
-  recursion, charging a parametric local-work term at each level.
-* Theorems {lit}`selectCostFuel_linear_bound` and {lit}`selectCost_linear_bound`:
-  the concrete cost is linear ({lit}`≤ 17 * a * n`) whenever the pivot rule
-  satisfies the CLRS {lit}`10 * branch ≤ 7 * n + 12` bound and the local work is
-  linear.
-* Definition {lit}`medianOfMediansPartitionPathCost` and theorem
-  {lit}`medianOfMediansPartitionPathCost_linear_bound`: the partition scans on
-  the selector's outer recursion path obey the explicit linear bound
-  {lit}`medianOfMediansPartitionPathCost k xs ≤ 17 * xs.length`.
-* Theorems {lit}`recursiveMedianOfMediansPivot?_partition_size_bound`,
-  {lit}`recursiveMedianOfMediansSelect?_isSome_of_lt`, and
-  {lit}`recursiveMedianOfMediansSelect?_correct`: a recursively computed
-  median-of-medians pivot retains the CLRS branch bound and yields a total,
-  rank-correct selector.
-* Definition {lit}`recursiveMedianOfMediansComparisonCost` and theorem
-  {lit}`recursiveMedianOfMediansComparisonCost_linear_bound`: the complete
-  comparison cost includes five-element grouping, recursive pivot selection,
-  the current partition, and the selected strict branch, and is at most
-  {lit}`100 * xs.length`.
+* {lit}`selectWithPivot?_correct` proves the pivot-parametric rank interface.
+* {lit}`fullGroupsOfFive_medianPivot_partition_size_bound` proves the CLRS
+  grouped-pivot branch bound.
+* {lit}`recursiveMedianOfMediansSelect?_correct` proves total rank correctness
+  for the executable recursive selector.
+* {lit}`recursiveMedianOfMediansComparisonCost_linear_bound` accounts for
+  grouping, nested pivot selection, partitioning, and recursive selection, with
+  total cost at most {lit}`100 * xs.length`.
 
-## Implementation details
+## Shared source support
 
-The randomized-selection analysis remains available outside the main sidebar:
+The Section 9.2 randomized analysis is stored below this module path so that it
+can reuse the pivot-parametric infrastructure.  It is a support page for 9.2,
+not an additional subsection of 9.3, and therefore stays outside the sidebar:
 
 * [Randomized SELECT Expected Time](CLRSLean/Chapter_09/Section_09_3_Deterministic_Select/Randomized_Select/)
 

--- a/docs/proof-audits/chapter-09-closure-2026-07-15.md
+++ b/docs/proof-audits/chapter-09-closure-2026-07-15.md
@@ -4,7 +4,7 @@ Date: 2026-07-15
 
 Status: `main-proof-complete`
 
-Core completion commit: `353ec4a`
+Main completion commit: `ad8b3a8` ([PR #92](https://github.com/TankTechnology/CLRS-Lean/pull/92))
 
 ## Acceptance Boundary
 

--- a/docs/proof-audits/chapter-completion-audit.md
+++ b/docs/proof-audits/chapter-completion-audit.md
@@ -115,9 +115,7 @@ When all boxes are checked, record:
 ```markdown
 | Chapter | Section | Auditor | Date | Commit |
 |---|---|---|---|---|
-| 9 | 9.1-9.3 | Codex | 2026-07-15 | 353ec4a |
-| 22 | 22.1-22.5 | Codex | 2026-07-10 | 1aeb257 |
-| 13 | 13.1 | (name) | 2026-07-01 | a6c71af |
+| XX | XX.1-XX.M | Name | YYYY-MM-DD | abc1234 |
 ```
 
 Add the row below the table in this file when the audit is complete.
@@ -126,3 +124,4 @@ Add the row below the table in this file when the audit is complete.
 
 | Chapter | Section | Auditor | Date | Commit |
 |---|---|---|---|---|
+| 9 | 9.1-9.3 | Codex | 2026-07-15 | [`ad8b3a8`](https://github.com/TankTechnology/CLRS-Lean/commit/ad8b3a865ce843addf0d77b55548b4d9a8cebad4) ([#92](https://github.com/TankTechnology/CLRS-Lean/pull/92)) |

--- a/docs/site-architecture.md
+++ b/docs/site-architecture.md
@@ -40,10 +40,26 @@ docs/workflows/chapter-workflow.md    maintainer workflow notes
 Lean literate source
 -> lake build
 -> lake build :literateHtml
--> scripts/optimize_literate_html.py
+-> scripts/prepare_literate_site.py
 -> _site
 -> GitHub Pages
 ```
+
+## Local Preview
+
+Build and preview the same optimized site that GitHub Pages publishes:
+
+```bash
+VERSO_OUT="$(lake query :literateHtml)"
+python3 scripts/check_literate_html_freshness.py "$VERSO_OUT"
+python3 scripts/prepare_literate_site.py "$VERSO_OUT" _site
+python3 -m http.server --directory _site 8000
+```
+
+Then open `http://localhost:8000/`.  Do not serve the raw Verso output
+directly: reader-sidebar pruning, large-page optimization, rendering checks,
+the project stylesheet, and the sitemap are all applied by the shared
+preparation command.
 
 `literate.toml` controls the sidebar order and page titles.  The public website
 should not depend on a hand-written `docs/site/index.html`.
@@ -61,8 +77,10 @@ them under the main section's module path (for example,
 control generation and search order even though they are not reader-visible
 navigation rows.
 
-Large generated proof pages are post-processed before deployment.  The optimizer
-keeps anchors, rendered Lean code, search assets, and copy buttons, while
+Large generated proof pages are post-processed before deployment.  The shared
+site-preparation command invokes the optimizer, rendering checks, stylesheet
+copy, and sitemap generation for both local previews and GitHub Pages.  The
+optimizer keeps anchors, rendered Lean code, search assets, and copy buttons, while
 removing tactic-state DOM and hover metadata that make browser parsing slow on
 long files such as the Huffman proof.  The same post-processing step prunes
 non-reader modules from the static sidebar HTML and turns any visible

--- a/scripts/check_repository.py
+++ b/scripts/check_repository.py
@@ -19,6 +19,7 @@ CHECK_SCRIPTS = [
     "scripts/test_literate_navigation.py",
     "scripts/test_optimize_literate_html.py",
     "scripts/test_check_literate_rendering.py",
+    "scripts/test_prepare_literate_site.py",
 ]
 
 

--- a/scripts/prepare_literate_site.py
+++ b/scripts/prepare_literate_site.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Assemble the optimized static site used by local previews and GitHub Pages."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.check_literate_rendering import check_site
+from scripts.generate_sitemap import iter_html_pages, page_url, render_sitemap
+from scripts.optimize_literate_html import iter_html_files, optimize_file
+
+
+DEFAULT_BASE_URL = "https://tanktechnology.github.io/CLRS-Lean/"
+DEFAULT_STYLESHEET = ROOT / "docs/literate/clrs-literate.css"
+
+
+@dataclass(frozen=True)
+class SitePreparationResult:
+    html_pages: int
+    optimized_pages: int
+    sitemap_urls: int
+
+
+def prepare_site(
+    source: Path,
+    destination: Path,
+    *,
+    stylesheet: Path = DEFAULT_STYLESHEET,
+    base_url: str = DEFAULT_BASE_URL,
+    lastmod: str | None = None,
+    strip_attrs_min_bytes: int = 1_000_000,
+) -> SitePreparationResult:
+    """Copy, optimize, validate, and index one Verso output directory."""
+    source = source.resolve()
+    destination = destination.resolve()
+    stylesheet = stylesheet.resolve()
+
+    if not source.is_dir():
+        raise ValueError(f"Verso output does not exist or is not a directory: {source}")
+    if not stylesheet.is_file():
+        raise ValueError(f"stylesheet does not exist or is not a file: {stylesheet}")
+    if (
+        destination == source
+        or source in destination.parents
+        or destination in source.parents
+    ):
+        raise ValueError("source and destination must not overlap")
+
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(source, destination)
+    shutil.copy2(stylesheet, destination / "clrs-literate.css")
+
+    html_files = list(iter_html_files([destination]))
+    optimized_pages = 0
+    for html_file in html_files:
+        if optimize_file(html_file, strip_attrs_min_bytes).changed:
+            optimized_pages += 1
+
+    failures = check_site(destination)
+    if failures:
+        details = "\n  ".join(failures)
+        raise ValueError(f"literate rendering checks failed:\n  {details}")
+
+    sitemap_pages = iter_html_pages(destination)
+    if not sitemap_pages:
+        raise ValueError(f"no HTML pages found under {destination}")
+    sitemap_urls = [page_url(destination, page, base_url) for page in sitemap_pages]
+    sitemap_lastmod = lastmod or dt.datetime.now(dt.timezone.utc).date().isoformat()
+    (destination / "sitemap.xml").write_text(
+        render_sitemap(sitemap_urls, sitemap_lastmod),
+        encoding="utf-8",
+        newline="",
+    )
+
+    return SitePreparationResult(
+        html_pages=len(html_files),
+        optimized_pages=optimized_pages,
+        sitemap_urls=len(sitemap_urls),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "source", type=Path, help="Raw Verso literate-html output directory."
+    )
+    parser.add_argument(
+        "destination", type=Path, help="Deployable static-site directory."
+    )
+    parser.add_argument(
+        "--stylesheet",
+        type=Path,
+        default=DEFAULT_STYLESHEET,
+        help="Stylesheet copied to clrs-literate.css in the destination.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help="Canonical public base URL used in sitemap.xml.",
+    )
+    parser.add_argument(
+        "--lastmod",
+        help="ISO date written into sitemap.xml (defaults to the current UTC date).",
+    )
+    args = parser.parse_args()
+
+    result = prepare_site(
+        args.source,
+        args.destination,
+        stylesheet=args.stylesheet,
+        base_url=args.base_url,
+        lastmod=args.lastmod,
+    )
+    print(
+        f"prepared {args.destination}: {result.html_pages} HTML pages, "
+        f"{result.optimized_pages} changed, {result.sitemap_urls} sitemap URLs"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_prepare_literate_site.py
+++ b/scripts/test_prepare_literate_site.py
@@ -1,0 +1,126 @@
+"""Tests for assembling the deployable CLRS-Lean literate site."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("prepare_literate_site.py")
+
+
+def load_preparer():
+    spec = importlib.util.spec_from_file_location("prepare_literate_site", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_module(site_root: Path, module_name: str, html: str) -> Path:
+    path = site_root.joinpath(*module_name.split("."), "index.html")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(html, encoding="utf-8")
+    return path
+
+
+class PrepareLiterateSiteTests(unittest.TestCase):
+    def test_rejects_a_destination_that_contains_the_source(self) -> None:
+        self.assertTrue(SCRIPT_PATH.is_file())
+        preparer = load_preparer()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            destination = root / "site"
+            source = destination / "raw"
+            source.mkdir(parents=True)
+            stylesheet = root / "clrs-literate.css"
+            stylesheet.write_text("body {}\n", encoding="utf-8")
+
+            caught: Exception | None = None
+            try:
+                preparer.prepare_site(
+                    source,
+                    destination,
+                    stylesheet=stylesheet,
+                )
+            except Exception as error:  # The assertions below check the contract.
+                caught = error
+
+            self.assertTrue(source.is_dir())
+            self.assertIsInstance(caught, ValueError)
+            self.assertIn("must not overlap", str(caught))
+
+    def test_builds_the_same_optimized_site_used_for_pages(self) -> None:
+        self.assertTrue(
+            SCRIPT_PATH.is_file(),
+            "prepare_literate_site.py must provide the shared assembly workflow",
+        )
+        preparer = load_preparer()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "verso-output"
+            destination = root / "site"
+            stylesheet = root / "clrs-literate.css"
+            stylesheet.write_text("body { color: black; }\n", encoding="utf-8")
+
+            parent = "CLRSLean.Chapter_09.Section_09_3_Deterministic_Select"
+            child = f"{parent}.Randomized_Select"
+            child_href = child.replace(".", "/") + "/"
+            write_module(
+                source,
+                parent,
+                f"""<!doctype html>
+<html><head><title>9.3</title></head><body>
+<nav class="module-tree">
+  <details><summary><a href="CLRSLean/Chapter_09/Section_09_3_Deterministic_Select/" title="{parent}">9.3</a></summary>
+    <div class="leaf"><a href="{child_href}" title="{child}">Randomized SELECT</a></div>
+  </details>
+</nav>
+<main><a href="{child_href}">Shared support page</a></main>
+</body></html>
+""",
+            )
+            write_module(source, child, "<html><body>Expected time</body></html>\n")
+            destination.mkdir()
+            (destination / "stale.html").write_text("stale", encoding="utf-8")
+
+            result = preparer.prepare_site(
+                source,
+                destination,
+                stylesheet=stylesheet,
+                base_url="https://example.test/CLRS-Lean/",
+                lastmod="2026-07-15",
+            )
+
+            parent_html = destination.joinpath(
+                *parent.split("."), "index.html"
+            ).read_text(encoding="utf-8")
+            sitemap = (destination / "sitemap.xml").read_text(encoding="utf-8")
+            stale_exists = (destination / "stale.html").exists()
+            stylesheet_text = (destination / "clrs-literate.css").read_text(
+                encoding="utf-8"
+            )
+
+        self.assertEqual(2, result.html_pages)
+        self.assertEqual(2, result.sitemap_urls)
+        self.assertFalse(stale_exists)
+        self.assertEqual("body { color: black; }\n", stylesheet_text)
+        self.assertNotIn(f'title="{child}"', parent_html)
+        self.assertIn("clrs-nav-state-script", parent_html)
+        self.assertIn(
+            "https://example.test/CLRS-Lean/CLRSLean/Chapter_09/"
+            "Section_09_3_Deterministic_Select/",
+            sitemap,
+        )
+        self.assertIn("<lastmod>2026-07-15</lastmod>", sitemap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add one tested site-preparation entry point shared by local previews and GitHub Pages
- simplify the Chapter 9, Section 9.2, and Section 9.3 reader-facing documentation while keeping the randomized support page reachable outside the sidebar
- correct the Chapter 9 closure audit to reference the merged main commit and PR #92

## Verification

- [x] `python3 scripts/check_repository.py`
- [x] `lake build CLRSLean.Chapter_09`
- [x] `lake env lean Tests/Chapter_09_Interface.lean`
- [x] `lake env lean Tests/Chapter_09_Closure.lean`
- [x] Chapter 9 `sorry`/`admit`/`axiom` scan
- [x] `git diff --check`

## Build note

A local full-site Verso generation was started but stopped after it spent several minutes processing unrelated long pages. The new assembly behavior is covered by its integration tests; the Pages workflow uses the same entry point for the complete deployment build.