### PR TITLE
feat(ch18): add mergeNodes_sorted + composedDelete proof roadmap

### DIFF
--- a/CLRSLean/Chapter_18/Section_18_3_B_Tree_Deletion.lean
+++ b/CLRSLean/Chapter_18/Section_18_3_B_Tree_Deletion.lean
@@ -49,8 +49,12 @@ Main results:
 Current gaps:
 
 - `composedDelete` is now defined (total, via `heightOf` termination) and
-  implements the CLRS merge-recurse strategy (case 2c simplified).  Invariant
-  preservation theorems (`WellFormed`) remain to be proved.
+  implements the CLRS merge-recurse strategy.  `mergeNodes_sorted` is proved.
+  The invariant preservation theorem (`composedDelete_wellFormed`) needs:
+  (1) a `rotateLeft` definition (mirror of the existing `rotateRight`) with
+  its preservation lemmas; (2) pre-emptive child-repair logic in
+  `composedDelete`; (3) the full four-component induction proof following the
+  `insertNonFull_wellFormed` pattern (see the roadmap below).
 - Disk-page semantics remain a strengthening target.
 -/
 
@@ -486,6 +490,63 @@ lemma mergeNodes_occupancy {t : Nat} (ht : 2 ≤ t)
     rcases hc with hc | hc
     · exact hL_sub c hc
     · exact hR_sub c hc
+
+/-! ## `mergeNodes` preserves `Sorted` -/
+
+lemma mergeNodes_sorted {lKeys rKeys : List Nat} {lCh rCh : List BTree} {sep : Nat}
+    (hL_s : Sorted (node lKeys lCh)) (hR_s : Sorted (node rKeys rCh))
+    (hL_le : ∀ k ∈ keysOf (node lKeys lCh), k ≤ sep)
+    (hR_ge : ∀ k ∈ keysOf (node rKeys rCh), sep ≤ k) :
+    Sorted (mergeNodes (node lKeys lCh) sep (node rKeys rCh)) := by
+  rw [mergeNodes_node]
+  unfold Sorted; unfold Sorted at hL_s hR_s
+  obtain ⟨hL_pw, hL_ch⟩ := hL_s
+  obtain ⟨hR_pw, hR_ch⟩ := hR_s
+  refine ⟨?_, ?_⟩
+  · have hL_all : ∀ k ∈ lKeys, k ≤ sep := by
+      intro k hk; apply hL_le k; simp [keysOf, hk]
+    have hR_all : ∀ k ∈ rKeys, sep ≤ k := by
+      intro k hk; apply hR_ge k; simp [keysOf, hk]
+    have h_sep_rKeys_pw : List.Pairwise (· ≤ ·) (sep :: rKeys) :=
+      List.Pairwise.cons hR_all hR_pw
+    have h_cross : ∀ a ∈ lKeys, ∀ b ∈ sep :: rKeys, a ≤ b := by
+      intro a ha b hb
+      rcases List.mem_cons.mp hb with (rfl | hb_rKeys)
+      · exact hL_all a ha
+      · exact le_trans (hL_all a ha) (hR_all b hb_rKeys)
+    rw [List.pairwise_append]
+    exact ⟨hL_pw, h_sep_rKeys_pw, h_cross⟩
+  · intro c hc
+    rw [List.mem_append] at hc
+    rcases hc with hc | hc
+    · exact hL_ch c hc
+    · exact hR_ch c hc
+
+/-! ## `composedDelete` preserves `WellFormed` — proof roadmap
+
+The main invariant theorem `composedDelete_wellFormed` states that for any
+`WellFormed` B-tree, `composedDelete` preserves `Sorted`, `ChildBounded`,
+`Occupancy`, and `SameDepth`.  The proof uses strong induction on `heightOf`
+with the three cases of the algorithm:
+
+1. **Leaf case**: `sortedRemove` reduces keys by at most 1.
+2. **Key-at-separator case**: merge neighboring children via `mergeNodes`
+   (using `mergeNodes_sorted`, `mergeNodes_sameDepth`, `mergeNodes_occupancy`),
+   then recurse.
+3. **Recurse-into-child case**: IH on the child.
+
+The remaining work is the **pre-emptive repair** logic (CLRS case 3): before
+case 3, ensure the target child has ≥ `t` keys by borrowing from a sibling
+(`rotateRight`/`rotateLeft`) or merging.  The building blocks are ready:
+`mergeNodes_sorted` (proved above), `mergeNodes_sameDepth`,
+`mergeNodes_occupancy`, and `rotateRight_preserves`.  What's missing:
+a `rotateLeft` definition (mirror of `rotateRight`) with its preservation
+lemmas, and the full `composedDelete_wellFormed` proof assembling all four
+invariant components.
+
+The proof structure follows the `insertNonFull_wellFormed` pattern from
+Section 18.2, using a custom `.induct` lemma for case analysis.
+-/
 
 /-- From `ChildBounded`, a node either has no children or has exactly one more
 child than keys. -/

--- a/CLRSLean/Chapter_18/Section_18_3_B_Tree_Deletion.lean
+++ b/CLRSLean/Chapter_18/Section_18_3_B_Tree_Deletion.lean
@@ -1016,6 +1016,43 @@ decreasing_by
     have hmem : child ∈ cs :=
       (List.mem_iff_getElem? (a := child) (l := cs)).mpr ⟨0, hc⟩
     exact heightOf_mem_lt hmem
+/-! ## `composedDelete` preserves `WellFormed` for leaves -/
+
+theorem composedDelete_leaf_wellFormed (t x : Nat) (ht : 2 ≤ t) (ks : List Nat)
+    (hwf : WellFormed t (node ks [])) :
+    WellFormed t (composedDelete t x (node ks [])) := by
+  have hleaf : composedDelete t x (node ks []) = node (sortedRemove x ks) [] := by
+    simp [composedDelete]
+  rw [hleaf]
+  obtain ⟨hs, hcb, hocc, hsd⟩ := hwf
+  -- Extract Sorted
+  have hs_keys : List.Pairwise (· ≤ ·) ks := by
+    unfold Sorted at hs; simp at hs; exact hs
+  -- Extract Occupancy bounds
+  unfold Occupancy at hocc
+  have hks_up : ks.length ≤ 2*t-1 := hocc.2.1
+  -- Build result components
+  have h_sorted : Sorted (node (sortedRemove x ks) []) := by
+    unfold Sorted; simp; exact sortedRemove_sorted_leaf x ks hs_keys
+  have h_childBounded : ChildBounded (node (sortedRemove x ks) []) :=
+    childBounded_node_nil (sortedRemove x ks)
+  have h_occupancy : Occupancy t true (node (sortedRemove x ks) []) := by
+    unfold Occupancy
+    refine ⟨?_, ?_, by simp, fun c hc => by simp at hc⟩
+    · -- lower bound: (if result = [] then 0 else 1) ≤ result.length
+      dsimp
+      by_cases h0 : (sortedRemove x ks).length = 0
+      · simp [h0]
+      · have h_low : 1 ≤ (sortedRemove x ks).length := by omega
+        simp [h0, h_low]
+    · -- upper bound: result.length ≤ 2*t-1
+      have hlen := sortedRemove_length_le x ks
+      omega
+  have h_sameDepth : SameDepth (node (sortedRemove x ks) []) :=
+    SameDepth.leaf (sortedRemove x ks)
+  unfold WellFormed
+  exact ⟨h_sorted, h_childBounded, h_occupancy, h_sameDepth⟩
+
 end BTree
 end Chapter18
 end CLRS

--- a/CLRSLean/Chapter_18/Section_18_3_B_Tree_Deletion.lean
+++ b/CLRSLean/Chapter_18/Section_18_3_B_Tree_Deletion.lean
@@ -854,6 +854,38 @@ lemma sortedRemove_sorted (x : Nat) : ∀ {ks : List Nat}, List.Pairwise (· ≤
       intro a ha
       exact hk a (mem_of_sortedRemove ha)
 
+/-! ### `sortedRemove` length bounds -/
+
+lemma sortedRemove_length_le (x : Nat) (ks : List Nat) :
+    (sortedRemove x ks).length ≤ ks.length := by
+  induction ks with
+  | nil => simp
+  | cons k ks ih =>
+    rw [sortedRemove_cons]; split <;> simp [ih]
+
+lemma sortedRemove_length_ge (x : Nat) (ks : List Nat) :
+    ks.length - 1 ≤ (sortedRemove x ks).length := by
+  induction ks with
+  | nil => simp
+  | cons k ks ih =>
+    rw [sortedRemove_cons]; split
+    · simp
+    · simp; omega
+
+/-! ### `sortedRemove` preserves leaf invariants -/
+
+lemma sortedRemove_sorted_leaf (x : Nat) (ks : List Nat)
+    (hs : List.Pairwise (· ≤ ·) ks) :
+    List.Pairwise (· ≤ ·) (sortedRemove x ks) := by
+  induction ks with
+  | nil => exact hs
+  | cons k ks ih =>
+    rw [sortedRemove_cons]; split
+    · exact hs.tail
+    · refine List.Pairwise.cons ?_ (ih hs.tail)
+      obtain ⟨hk, _⟩ := List.pairwise_cons.mp hs
+      intro a ha; exact hk a (mem_of_sortedRemove ha)
+
 /-! ## Composed delete (CLRS B-TREE-DELETE) -/
 
 


### PR DESCRIPTION
Partial progress toward closing the Ch18 B-tree deletion gap. Adds mergeNodes_sorted lemma and proof roadmap. All checks pass.