### PR TITLE
feat(ext): Extensions area + randomized treap (correctness + expected-depth analysis)

### DIFF
--- a/CLRSLean.lean
+++ b/CLRSLean.lean
@@ -34,6 +34,7 @@ import CLRSLean.Chapter_26
 import CLRSLean.Chapter_27
 import CLRSLean.Chapter_32
 import CLRSLean.Chapter_33
+import CLRSLean.Extensions
 import CLRSLean.Progress
 import CLRSLean.Status
 import CLRSLean.Workflow

--- a/CLRSLean/Extensions.lean
+++ b/CLRSLean/Extensions.lean
@@ -1,3 +1,7 @@
+import CLRSLean.Extensions.RandomizedTreap
+import CLRSLean.Extensions.TreapHeight
+import CLRSLean.Extensions.TreapRandom
+
 /-!
 # Extensions beyond the textbook
 
@@ -24,6 +28,8 @@ Planned extensions:
 - **Edit distance**: sequence alignment as a refinement of the Chapter 15
   longest-common-subsequence dynamic program.
 
-Status: no extension promoted yet; the first prototype (the randomized treap)
-lives in {lit}`CLRSLean/Extensions/RandomizedTreap.lean`.
+Status: no extension has been promoted to the textbook ledger.  The randomized
+treap prototype has kernel-checked executable correctness and expected-depth
+analysis; {lit}`CLRSLean/Extensions/TreapHeight.lean` contains the next
+expected-height proof layer, whose final bound remains future work.
 -/

--- a/CLRSLean/Extensions.lean
+++ b/CLRSLean/Extensions.lean
@@ -1,0 +1,29 @@
+/-!
+# Extensions beyond the textbook
+
+This area collects results that go **one notch beyond CLRS** without leaving
+its orbit: classic structures the book only sketches or leaves to exercises and
+problems, natural variants of the verified data structures in the main
+chapters, and refinements that exercise the reusable toolkits
+({lit}`ProofPatterns`, the finite-probability layer) on new objects.
+
+Extensions are deliberately kept **out of the textbook-coverage ledger**: the
+progress CSV counts what the book claims, and this area is where the project
+goes further.  A module is only registered in {lit}`literate.toml` (and
+therefore rendered in the site sidebar) once it is kernel-clean; prototypes
+stay unregistered while their theorem interfaces settle.
+
+Planned extensions:
+
+- **Randomized treap**: an executable randomized binary search tree with
+  membership correctness and an expected {lit}`O(log n)` height bound,
+  exercising the finite-expectation layer on a new object.
+- **Splay tree**: amortized analysis via the potential method of Chapter 17.
+- **Persistent dynamic sets**: CLRS Problem 13-1, versioned red-black trees
+  with path copying.
+- **Edit distance**: sequence alignment as a refinement of the Chapter 15
+  longest-common-subsequence dynamic program.
+
+Status: no extension promoted yet; the first prototype (the randomized treap)
+lives in {lit}`CLRSLean/Extensions/RandomizedTreap.lean`.
+-/

--- a/CLRSLean/Extensions/RandomizedTreap.lean
+++ b/CLRSLean/Extensions/RandomizedTreap.lean
@@ -375,6 +375,192 @@ theorem insert_member [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α
   rw [member_iff_keys x (insert x p t) (IsBST_insert x p t h), keys_insert]
   exact Finset.mem_insert_self x (keys t)
 
+/-! ## Heap correctness
+
+A treap must also satisfy the *max-heap* property on priorities: every node's
+priority is at least its children's.  This section proves that `insert`
+preserves it.  The subtle part is that a single rotation repairs exactly one
+heap violation along the insertion path; the structural fact that makes it
+tick is `prioOf_insert` — insertion attaches the new priority `p` only to the
+new key `x` and leaves every existing key's priority untouched. -/
+
+/-- The priority attached to a key `y` in a treap (`0` if `y` is absent). -/
+def prioOf [LinearOrder α] [DecidableEq α] [DecidableLT α] (t : Treap α) (y : α) : Nat :=
+  match t with
+  | nil => 0
+  | node k p l r =>
+      if y = k then p
+      else if y < k then prioOf l y
+      else prioOf r y
+
+/-- `prioLE p t`: the priority of every key present in `t` is at most `p`. -/
+def prioLE [LinearOrder α] [DecidableEq α] [DecidableLT α] (p : Nat) (t : Treap α) : Prop :=
+  ∀ y ∈ keys t, prioOf t y ≤ p
+
+/-- A treap is a *max-heap on priorities* when every node's priority is at
+least the priorities of its children, recursively. -/
+def IsHeap [LinearOrder α] [DecidableEq α] [DecidableLT α] : Treap α → Prop
+  | nil => True
+  | node _ p l r => IsHeap l ∧ IsHeap r ∧ prioLE p l ∧ prioLE p r
+
+/-- Right rotation preserves the priority attached to every key, on a
+well-formed (BST) treap. -/
+theorem prioOf_rotR [LinearOrder α] [DecidableEq α] [DecidableLT α] {t : Treap α}
+    (h : IsBST t) (y : α) : prioOf (rotR t) y = prioOf t y := by
+  cases t with
+  | nil => rfl
+  | node a pa l r =>
+      cases l with
+      | nil => rfl
+      | node b pb lb rb =>
+          rcases h with ⟨hl, hr, hlt, hgt⟩
+          rcases hl with ⟨hlb, hrb, hltb, hgtrb⟩
+          have hba : b < a := hlt b (by simp [keys])
+          by_cases h1 : y = b
+          · simp [prioOf, rotR, h1, hba, ne_of_lt hba]
+          · have h1ne : y ≠ b := h1
+            by_cases h2 : y < b
+            · have hya : y < a := lt_trans h2 hba
+              have hyane : y ≠ a := ne_of_lt hya
+              simp [prioOf, rotR, h1ne, h2, hya, hyane]
+            · by_cases h3 : y = a
+              · have hanb : ¬ a < b := fun hab => lt_asymm hab hba
+                simp [prioOf, rotR, h1ne, h2, h3, Ne.symm (ne_of_lt hba), hanb]
+              · have h3ne : y ≠ a := h3
+                by_cases h4 : y < a
+                · simp [prioOf, rotR, h1ne, h2, h3ne, h4]
+                · simp [prioOf, rotR, h1ne, h2, h3ne, h4]
+
+/-- Left rotation preserves the priority attached to every key, on a
+well-formed (BST) treap. -/
+theorem prioOf_rotL [LinearOrder α] [DecidableEq α] [DecidableLT α] {t : Treap α}
+    (h : IsBST t) (y : α) : prioOf (rotL t) y = prioOf t y := by
+  cases t with
+  | nil => rfl
+  | node a pa l r =>
+      cases r with
+      | nil => rfl
+      | node b pb lb rb =>
+          rcases h with ⟨hl, hr, hlt, hgt⟩
+          rcases hr with ⟨hlb, hrb, hltb, hgtrb⟩
+          have hab : a < b := hgt b (by simp [keys])
+          by_cases h1 : y = a
+          · simp [prioOf, rotL, h1, hab, ne_of_lt hab]
+          · have h1ne : y ≠ a := h1
+            by_cases h2 : y < a
+            · have hyb : y < b := lt_trans h2 hab
+              have hybne : y ≠ b := ne_of_lt hyb
+              simp [prioOf, rotL, h1ne, h2, hyb, hybne]
+            · by_cases h3 : y = b
+              · have hbna : ¬ b < a := fun hba => lt_asymm hba hab
+                simp [prioOf, rotL, h1ne, h2, h3, Ne.symm (ne_of_lt hab), hbna]
+              · have h3ne : y ≠ b := h3
+                by_cases h4 : y < b
+                · simp [prioOf, rotL, h1ne, h2, h3ne, h4]
+                · simp [prioOf, rotL, h1ne, h2, h3ne, h4]
+
+/-- Inserting a fresh key attaches the new priority `p` exactly to the new key
+`x` and leaves every existing key's priority untouched. -/
+theorem prioOf_insert [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p : Nat)
+    (t : Treap α) (h : IsBST t) (hx : x ∉ keys t) :
+    ∀ y : α, prioOf (insert x p t) y = if y = x then p else prioOf t y := by
+  intro y
+  induction t with
+  | nil => simp [insert, prioOf]
+  | node k pk l r ih_l ih_r =>
+      rcases h with ⟨hl, hr, hlt, hgt⟩
+      have hxl : x ∉ keys l := by
+        intro hxl'
+        exact hx (by simp [keys, hxl'])
+      have hxr : x ∉ keys r := by
+        intro hxr'
+        exact hx (by simp [keys, hxr'])
+      by_cases h1 : x < k
+      · by_cases h2 : k < x
+        · exfalso
+          exact (lt_asymm h1 h2)
+        · -- x < k
+          cases hl' : insert x p l with
+          | nil => exfalso; exact insert_ne_nil x p l hl'
+          | node b pb lb rb =>
+              have hlbst : IsBST (node b pb lb rb) := by rw [← hl']; exact IsBST_insert x p l hl
+              have hnew : IsBST (node k pk (node b pb lb rb) r) := by
+                refine ⟨hlbst, hr, ?_, hgt⟩
+                intro z hz
+                have hzins : z ∈ keys (insert x p l) := by rw [hl']; exact hz
+                have hzkeys : z ∈ Insert.insert x (keys l) := by rw [keys_insert x p l] at hzins; exact hzins
+                by_cases hzx : z = x
+                · rw [hzx]; exact h1
+                · exact hlt z (by simpa [hzx] using hzkeys)
+              by_cases hrot : pb > pk
+              · -- rotR branch
+                simp [insert, h1, hl', hrot]
+                have hprio : prioOf (rotR (node k pk (node b pb lb rb) r)) y =
+                    prioOf (node k pk (node b pb lb rb) r) y := prioOf_rotR hnew y
+                rw [hprio]
+                by_cases hyk : y = k
+                · simp [prioOf, hyk, Ne.symm (ne_of_lt h1)]
+                · have hykne : y ≠ k := hyk
+                  by_cases hylt : y < k
+                  · rw [← hl']
+                    simp [prioOf, hykne, hylt]
+                    exact ih_l hl hxl
+                  · have hyxne : y ≠ x := fun hyx => hylt (by simpa [hyx] using h1)
+                    simp [prioOf, hykne, hylt, hyxne]
+              · simp [insert, h1, hl', hrot]
+                by_cases hyk : y = k
+                · simp [prioOf, hyk, Ne.symm (ne_of_lt h1)]
+                · have hykne : y ≠ k := hyk
+                  by_cases hylt : y < k
+                  · rw [← hl']
+                    simp [prioOf, hykne, hylt]
+                    exact ih_l hl hxl
+                  · have hyxne : y ≠ x := fun hyx => hylt (by simpa [hyx] using h1)
+                    simp [prioOf, hykne, hylt, hyxne]
+      · by_cases h2 : k < x
+        · -- k < x
+          cases hr' : insert x p r with
+          | nil => exfalso; exact insert_ne_nil x p r hr'
+          | node b pb lb rb =>
+              have hrbst : IsBST (node b pb lb rb) := by rw [← hr']; exact IsBST_insert x p r hr
+              have hnew : IsBST (node k pk l (node b pb lb rb)) := by
+                refine ⟨hl, hrbst, hlt, ?_⟩
+                intro z hz
+                have hzins : z ∈ keys (insert x p r) := by rw [hr']; exact hz
+                have hzkeys : z ∈ Insert.insert x (keys r) := by rw [keys_insert x p r] at hzins; exact hzins
+                by_cases hzx : z = x
+                · rw [hzx]; exact h2
+                · exact hgt z (by simpa [hzx] using hzkeys)
+              by_cases hrot : pb > pk
+              · -- rotL branch
+                simp [insert, h1, h2, hr', hrot]
+                have hprio : prioOf (rotL (node k pk l (node b pb lb rb))) y =
+                    prioOf (node k pk l (node b pb lb rb)) y := prioOf_rotL hnew y
+                rw [hprio]
+                by_cases hyk : y = k
+                · simp [prioOf, hyk, ne_of_lt h2]
+                · have hykne : y ≠ k := hyk
+                  by_cases hylt : y < k
+                  · have hyxne : y ≠ x := fun hyx => h1 (by simpa [hyx] using hylt)
+                    simp [prioOf, hykne, hylt, hyxne]
+                  · rw [← hr']
+                    simp [prioOf, hykne, hylt]
+                    exact ih_r hr hxr
+              · simp [insert, h1, h2, hr', hrot]
+                by_cases hyk : y = k
+                · simp [prioOf, hyk, ne_of_lt h2]
+                · have hykne : y ≠ k := hyk
+                  by_cases hylt : y < k
+                  · have hyxne : y ≠ x := fun hyx => h1 (by simpa [hyx] using hylt)
+                    simp [prioOf, hykne, hylt, hyxne]
+                  · rw [← hr']
+                    simp [prioOf, hykne, hylt]
+                    exact ih_r hr hxr
+        · -- x = k (impossible: x is fresh)
+          have hxk : x = k := le_antisymm (le_of_not_gt h2) (le_of_not_gt h1)
+          exfalso
+          exact hx (by simp [keys, hxk])
+
 end Treap
 
 end CLRS.Extensions

--- a/CLRSLean/Extensions/RandomizedTreap.lean
+++ b/CLRSLean/Extensions/RandomizedTreap.lean
@@ -13,25 +13,26 @@ random, the treap on a fixed set of {lit}`(key, priority)` pairs is unique and
 has expected height {lit}`O(log n)`, which makes a treap a randomized balanced
 BST.
 
-This module is a **prototype**: the executable definitions and the two
-membership theorems are kernel-checked, but the headline *expected-height*
-result is not yet stated (it needs the finite-expectation layer).  The module
-is **not** registered in {lit}`literate.toml` and does not appear on the site
-until it is promoted.
+This module is a **prototype**: the executable `insert`/`member` and the
+*correctness* half — membership, BST preservation, and max-heap preservation —
+are all kernel-checked.  The headline *expected-height* result is the next
+planned step (it needs the finite-expectation layer).  The module is **not**
+registered in {lit}`literate.toml` and does not appear on the site until it is
+promoted.
 
 The membership theorems carry an {lit}`IsBST` (binary-search-tree) hypothesis:
 the executable {lit}`member` really is a guided search, and for a non-BST tree
 a rotation can change what the search finds, so the statement is only
 meaningful for well-formed trees.
 
-Main results:
+Main results (all kernel-checked):
 
-- Theorem {lit}`keys_insert`: inserting {lit}`(x, p)` adds exactly {lit}`x` to
-  the key set.
-- Theorem {lit}`member_insert`: for well-formed trees, membership of
-  {lit}`insert x p t` equals the old membership together with the new key.
-- Theorem {lit}`insert_member`: after inserting {lit}`x`, searching for
-  {lit}`x` succeeds.
+- Membership: {lit}`keys_insert`, {lit}`member_iff_keys`, {lit}`member_insert`,
+  {lit}`insert_member`.
+- BST preservation: {lit}`IsBST_insert` (with {lit}`IsBST_rotL`/`IsBST_rotR`).
+- Heap preservation: {lit}`prioOf_insert` (the structural core),
+  {lit}`IsHeap_insert` (the capstone), with {lit}`prioLE_insert`,
+  {lit}`insert_of_mem_keys`, {lit}`IsHeap_rotL`/`IsHeap_rotR`.
 
 Planned (not yet stated — needs the finite-expectation layer):
 

--- a/CLRSLean/Extensions/RandomizedTreap.lean
+++ b/CLRSLean/Extensions/RandomizedTreap.lean
@@ -378,13 +378,15 @@ theorem insert_member [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α
 /-! ## Heap correctness
 
 A treap must also satisfy the *max-heap* property on priorities: every node's
-priority is at least its children's.  This section proves that `insert`
+priority is at least its children's.  This section proves that {lit}`insert`
 preserves it.  The subtle part is that a single rotation repairs exactly one
 heap violation along the insertion path; the structural fact that makes it
-tick is `prioOf_insert` — insertion attaches the new priority `p` only to the
-new key `x` and leaves every existing key's priority untouched. -/
+tick is {lit}`prioOf_insert` — insertion attaches the new priority {lit}`p`
+only to the new key {lit}`x` and leaves every existing key's priority
+untouched. -/
 
-/-- The priority attached to a key `y` in a treap (`0` if `y` is absent). -/
+/-- The priority attached to a key {lit}`y` in a treap ({lit}`0` if {lit}`y`
+is absent). -/
 def prioOf [LinearOrder α] [DecidableEq α] [DecidableLT α] (t : Treap α) (y : α) : Nat :=
   match t with
   | nil => 0
@@ -393,7 +395,8 @@ def prioOf [LinearOrder α] [DecidableEq α] [DecidableLT α] (t : Treap α) (y 
       else if y < k then prioOf l y
       else prioOf r y
 
-/-- `prioLE p t`: the priority of every key present in `t` is at most `p`. -/
+/-- {lit}`prioLE p t`: the priority of every key present in {lit}`t` is at
+most {lit}`p`. -/
 def prioLE [LinearOrder α] [DecidableEq α] [DecidableLT α] (p : Nat) (t : Treap α) : Prop :=
   ∀ y ∈ keys t, prioOf t y ≤ p
 
@@ -459,8 +462,8 @@ theorem prioOf_rotL [LinearOrder α] [DecidableEq α] [DecidableLT α] {t : Trea
                 · simp [prioOf, rotL, h1ne, h2, h3ne, h4]
                 · simp [prioOf, rotL, h1ne, h2, h3ne, h4]
 
-/-- Inserting a fresh key attaches the new priority `p` exactly to the new key
-`x` and leaves every existing key's priority untouched. -/
+/-- Inserting a fresh key attaches the new priority {lit}`p` exactly to the
+new key {lit}`x` and leaves every existing key's priority untouched. -/
 theorem prioOf_insert [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p : Nat)
     (t : Treap α) (h : IsBST t) (hx : x ∉ keys t) :
     ∀ y : α, prioOf (insert x p t) y = if y = x then p else prioOf t y := by
@@ -560,6 +563,183 @@ theorem prioOf_insert [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α
           have hxk : x = k := le_antisymm (le_of_not_gt h2) (le_of_not_gt h1)
           exfalso
           exact hx (by simp [keys, hxk])
+
+/-- Inserting an already-present key leaves the treap unchanged (duplicate
+keys are ignored), on a well-formed treap. -/
+theorem insert_of_mem_keys [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p : Nat)
+    (t : Treap α) (h : IsBST t) (hh : IsHeap t) : x ∈ keys t → insert x p t = t := by
+  intro hx
+  induction t with
+  | nil => simp [keys] at hx
+  | node k pk l r ih_l ih_r =>
+      rcases h with ⟨hl, hr, hlt, hgt⟩
+      rcases hh with ⟨hhl, hhr, hpl, hpr⟩
+      by_cases h1 : x < k
+      · by_cases h2 : k < x
+        · exfalso
+          exact (lt_asymm h1 h2)
+        · -- x < k: the BST routes x into the left subtree
+          have hxl : x ∈ keys l := by
+            have hx' : x ∈ Insert.insert k (keys l ∪ keys r) := by simpa [keys] using hx
+            have hxk : x ≠ k := ne_of_lt h1
+            have hxnr : x ∉ keys r := by
+              intro hxr
+              exact (lt_asymm h1 (hgt x hxr))
+            simpa [hxk, hxnr] using hx'
+          have hrec : insert x p l = l := ih_l hl hhl hxl
+          simp [insert, h1, hrec]
+          cases l with
+          | nil => simp
+          | node b pb lb rb =>
+              have hpb_pk : pb ≤ pk := by
+                simpa [prioOf] using hpl b (by simp [keys])
+              by_cases hrot : pb > pk
+              · exfalso
+                exact (not_lt_of_ge hpb_pk) hrot
+              · simp [hrot]
+      · by_cases h2 : k < x
+        · -- k < x: the BST routes x into the right subtree
+          have hxr : x ∈ keys r := by
+            have hx' : x ∈ Insert.insert k (keys l ∪ keys r) := by simpa [keys] using hx
+            have hxk : x ≠ k := ne_of_gt h2
+            have hxnl : x ∉ keys l := by
+              intro hxl
+              exact (lt_asymm (hlt x hxl) h2)
+            simpa [hxk, hxnl] using hx'
+          have hrec : insert x p r = r := ih_r hr hhr hxr
+          simp [insert, h1, h2, hrec]
+          cases r with
+          | nil => simp
+          | node b pb lb rb =>
+              have hpb_pk : pb ≤ pk := by
+                simpa [prioOf] using hpr b (by simp [keys])
+              by_cases hrot : pb > pk
+              · exfalso
+                exact (not_lt_of_ge hpb_pk) hrot
+              · simp [hrot]
+        · -- x = k: the node is returned unchanged
+          simp [insert, h1, h2]
+
+/-- Inserting a key of priority {lit}`p ≤ c` into a treap whose priorities are
+all at most {lit}`c` keeps every priority at most {lit}`c`. -/
+theorem prioLE_insert [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p c : Nat)
+    (t : Treap α) (h : IsBST t) (hh : IsHeap t) (hc : prioLE c t) (hp : p ≤ c) :
+    prioLE c (insert x p t) := by
+  unfold prioLE
+  intro y hy
+  have hy' : y ∈ Insert.insert x (keys t) := by
+    rw [keys_insert x p t] at hy
+    exact hy
+  by_cases hxm : x ∈ keys t
+  · -- duplicate: insert keeps the tree, so the bound is unchanged
+    have hdup : insert x p t = t := insert_of_mem_keys x p t h hh hxm
+    rw [hdup] at hy ⊢
+    exact hc y hy
+  · -- fresh key: the only new priority is `p`, which is already ≤ c
+    by_cases hyx : y = x
+    · rw [prioOf_insert x p t h hxm y]
+      simp [hyx]
+      exact hp
+    · have hyt : y ∈ keys t := by
+        simpa [hyx] using hy'
+      rw [prioOf_insert x p t h hxm y]
+      simp [hyx]
+      exact hc y hyt
+
+/-- The priority of an absent key is {lit}`0`. -/
+theorem prioOf_eq_zero_of_not_mem [LinearOrder α] [DecidableEq α] [DecidableLT α] {t : Treap α}
+    {y : α} (h : y ∉ keys t) : prioOf t y = 0 := by
+  induction t with
+  | nil => rfl
+  | node k pk l r ih_l ih_r =>
+      have hyk : y ≠ k := by
+        intro hyk
+        exact h (by simp [keys, hyk])
+      by_cases hylt : y < k
+      · have hyl : y ∉ keys l := by
+          intro hyl'
+          exact h (by simp [keys, hyl'])
+        simp [prioOf, hyk, hylt]
+        exact ih_l hyl
+      · have hyr : y ∉ keys r := by
+          intro hyr'
+          exact h (by simp [keys, hyr'])
+        simp [prioOf, hyk, hylt]
+        exact ih_r hyr
+
+/-- A {lit}`prioLE` bound applies to the priority of every key, present or
+absent. -/
+theorem prioOf_le_of_prioLE [LinearOrder α] [DecidableEq α] [DecidableLT α] {t : Treap α}
+    {c : Nat} (h : prioLE c t) : ∀ y, prioOf t y ≤ c := by
+  intro y
+  by_cases hym : y ∈ keys t
+  · exact h y hym
+  · have hz : prioOf t y = 0 := prioOf_eq_zero_of_not_mem hym
+    rw [hz]
+    exact Nat.zero_le c
+
+/-- Promoting the left child above the root keeps the max-heap property, given
+that the promoted child's priority is at least the root's and the moved subtree
+stays bounded by the root's priority. -/
+theorem IsHeap_rotR [LinearOrder α] [DecidableEq α] [DecidableLT α] {a b : α} {pa pb : Nat}
+    {lb rb r : Treap α} (hl' : IsHeap (node b pb lb rb)) (hr : IsHeap r)
+    (hpb : pa ≤ pb) (hpa_rb : prioLE pa rb) (hpa_r : prioLE pa r) :
+    IsHeap (rotR (node a pa (node b pb lb rb) r)) := by
+  rcases hl' with ⟨hlb, hrb, hpb_lb, hpb_rb⟩
+  change IsHeap (node b pb lb (node a pa rb r))
+  refine ⟨hlb, ?_, hpb_lb, ?_⟩
+  · -- IsHeap (node a pa rb r)
+    refine ⟨hrb, hr, hpa_rb, hpa_r⟩
+  · -- prioLE pb (node a pa rb r)
+    unfold prioLE
+    intro y hy
+    have hy' : y ∈ Insert.insert a (keys rb ∪ keys r) := by simpa [keys] using hy
+    by_cases hya : y = a
+    · rw [hya]
+      have hpa_prio : prioOf (node a pa rb r) a = pa := by simp [prioOf]
+      rw [hpa_prio]
+      exact hpb
+    · have hya_ne : y ≠ a := hya
+      by_cases hylt : y < a
+      · have hprio : prioOf (node a pa rb r) y = prioOf rb y := by
+          simp [prioOf, hya_ne, hylt]
+        rw [hprio]
+        exact prioOf_le_of_prioLE hpb_rb y
+      · have hprio : prioOf (node a pa rb r) y = prioOf r y := by
+          simp [prioOf, hya_ne, hylt]
+        rw [hprio]
+        exact le_trans (prioOf_le_of_prioLE hpa_r y) hpb
+
+/-- Promoting the right child above the root keeps the max-heap property,
+symmetrically. -/
+theorem IsHeap_rotL [LinearOrder α] [DecidableEq α] [DecidableLT α] {a b : α} {pa pb : Nat}
+    {l lb rb : Treap α} (hl : IsHeap l) (hr' : IsHeap (node b pb lb rb))
+    (hpb : pa ≤ pb) (hpa_lb : prioLE pa lb) (hpa_l : prioLE pa l) :
+    IsHeap (rotL (node a pa l (node b pb lb rb))) := by
+  rcases hr' with ⟨hlb, hrb, hpb_lb, hpb_rb⟩
+  change IsHeap (node b pb (node a pa l lb) rb)
+  refine ⟨?_, hrb, ?_, hpb_rb⟩
+  · -- IsHeap (node a pa l lb)
+    refine ⟨hl, hlb, hpa_l, hpa_lb⟩
+  · -- prioLE pb (node a pa l lb)
+    unfold prioLE
+    intro y hy
+    have hy' : y ∈ Insert.insert a (keys l ∪ keys lb) := by simpa [keys] using hy
+    by_cases hya : y = a
+    · rw [hya]
+      have hpa_prio : prioOf (node a pa l lb) a = pa := by simp [prioOf]
+      rw [hpa_prio]
+      exact hpb
+    · have hya_ne : y ≠ a := hya
+      by_cases hylt : y < a
+      · have hprio : prioOf (node a pa l lb) y = prioOf l y := by
+          simp [prioOf, hya_ne, hylt]
+        rw [hprio]
+        exact le_trans (prioOf_le_of_prioLE hpa_l y) hpb
+      · have hprio : prioOf (node a pa l lb) y = prioOf lb y := by
+          simp [prioOf, hya_ne, hylt]
+        rw [hprio]
+        exact le_trans (prioOf_le_of_prioLE hpa_lb y) hpb
 
 end Treap
 

--- a/CLRSLean/Extensions/RandomizedTreap.lean
+++ b/CLRSLean/Extensions/RandomizedTreap.lean
@@ -1,0 +1,380 @@
+import Mathlib.Tactic
+
+-- Prototype in development: silence the unused-simp-argument linter noise.
+set_option linter.unusedSimpArgs false
+
+/-!
+# Randomized treap (prototype)
+
+A **treap** is a binary search tree whose nodes also carry a priority, kept as
+a heap: every node's priority is at least the priorities of its children (a
+*max-heap* order).  If the priorities are distinct and chosen uniformly at
+random, the treap on a fixed set of {lit}`(key, priority)` pairs is unique and
+has expected height {lit}`O(log n)`, which makes a treap a randomized balanced
+BST.
+
+This module is a **prototype**: the executable definitions and the two
+membership theorems are kernel-checked, but the headline *expected-height*
+result is not yet stated (it needs the finite-expectation layer).  The module
+is **not** registered in {lit}`literate.toml` and does not appear on the site
+until it is promoted.
+
+The membership theorems carry an {lit}`IsBST` (binary-search-tree) hypothesis:
+the executable {lit}`member` really is a guided search, and for a non-BST tree
+a rotation can change what the search finds, so the statement is only
+meaningful for well-formed trees.
+
+Main results:
+
+- Theorem {lit}`keys_insert`: inserting {lit}`(x, p)` adds exactly {lit}`x` to
+  the key set.
+- Theorem {lit}`member_insert`: for well-formed trees, membership of
+  {lit}`insert x p t` equals the old membership together with the new key.
+- Theorem {lit}`insert_member`: after inserting {lit}`x`, searching for
+  {lit}`x` succeeds.
+
+Planned (not yet stated — needs the finite-expectation layer):
+
+- Expected height {lit}`O(log n)` under uniformly random distinct priorities,
+  using {lit}`CLRSLean.Probability.FiniteExpectation`.
+
+Notation conventions:
+
+- {lit}`α` : key type with decidable linear order
+- priority : {lit}`Nat`, treated as an opaque tie-breaker
+- {lit}`IsBST t` : {lit}`t` is a binary search tree on its keys
+-/
+
+namespace CLRS.Extensions
+
+/-- A treap over keys {lit}`α`: either empty, or a node carrying a key, a priority,
+and left/right subtrees. -/
+inductive Treap (α : Type u) where
+  | nil : Treap α
+  | node (key : α) (prio : Nat) (left right : Treap α) : Treap α
+  deriving Repr
+
+namespace Treap
+
+/-- The height of a treap: the number of nodes on a longest root-to-leaf path. -/
+def height : Treap α → Nat
+  | nil => 0
+  | node _ _ l r => 1 + max (height l) (height r)
+
+/-- The finite set of keys occurring in a treap. -/
+def keys [DecidableEq α] : Treap α → Finset α
+  | nil => ∅
+  | node k _ l r => Insert.insert k (keys l ∪ keys r)
+
+/-- Membership test: whether {lit}`x` occurs as a key (guided search over the
+BST). -/
+def member [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) : Treap α → Bool
+  | nil => false
+  | node k _ l r =>
+      if x = k then true
+      else if x < k then member x l
+      else member x r
+
+/-- Right rotation: promote the left child to the root. -/
+def rotR : Treap α → Treap α
+  | node a pa (node b pb lb rb) r => node b pb lb (node a pa rb r)
+  | t => t
+
+/-- Left rotation: promote the right child to the root. -/
+def rotL : Treap α → Treap α
+  | node a pa l (node b pb lb rb) => node b pb (node a pa l lb) rb
+  | t => t
+
+/-- Insert {lit}`(x, p)` into a treap, preserving the BST order on keys and the
+max-heap order on priorities.  Existing keys are kept unchanged. -/
+def insert [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p : Nat) : Treap α → Treap α
+  | nil => node x p nil nil
+  | node k pk l r =>
+      if x < k then
+        let l' := insert x p l
+        match l' with
+        | node _ p' _ _ => if p' > pk then rotR (node k pk l' r) else node k pk l' r
+        | nil => node k pk l' r
+      else if k < x then
+        let r' := insert x p r
+        match r' with
+        | node _ p' _ _ => if p' > pk then rotL (node k pk l r') else node k pk l r'
+        | nil => node k pk l r'
+      else node k pk l r
+
+/-- {lit}`insert` never returns the empty tree. -/
+theorem insert_ne_nil [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p : Nat)
+    (t : Treap α) : insert x p t ≠ nil := by
+  induction t with
+  | nil => simp [insert]
+  | node k pk l r ih_l ih_r =>
+      by_cases h1 : x < k
+      · -- x < k: insert follows the left branch and always returns a node
+        simp [insert, h1]
+        cases insert x p l with
+        | nil => simp
+        | node b pb lb rb =>
+            by_cases hrot : pb > pk
+            · simp [rotR, hrot]
+            · simp [hrot]
+      · by_cases h2 : k < x
+        · -- k < x: insert follows the right branch
+          simp [insert, h1, h2]
+          cases insert x p r with
+          | nil => simp
+          | node b pb lb rb =>
+              by_cases hrot : pb > pk
+              · simp [rotL, hrot]
+              · simp [hrot]
+        · -- x = k: tree unchanged
+          simp [insert, h1, h2]
+
+/-- Right rotation preserves the key set. -/
+theorem keys_rotR [DecidableEq α] (t : Treap α) : keys (rotR t) = keys t := by
+  cases t with
+  | nil => rfl
+  | node a pa l r =>
+      cases l with
+      | nil => rfl
+      | node b pb lb rb =>
+          ext y
+          simp [keys, rotR, Finset.mem_insert, Finset.mem_union, or_assoc, or_left_comm, or_comm]
+
+/-- Left rotation preserves the key set. -/
+theorem keys_rotL [DecidableEq α] (t : Treap α) : keys (rotL t) = keys t := by
+  cases t with
+  | nil => rfl
+  | node a pa l r =>
+      cases r with
+      | nil => rfl
+      | node b pb lb rb =>
+          ext y
+          simp [keys, rotL, Finset.mem_insert, Finset.mem_union, or_assoc, or_left_comm, or_comm]
+
+/-- Inserting {lit}`(x, p)` adds exactly the key {lit}`x` to the key set. -/
+theorem keys_insert [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p : Nat)
+    (t : Treap α) : keys (insert x p t) = Insert.insert x (keys t) := by
+  induction t with
+  | nil => simp [insert, keys]
+  | node k pk l r ih_l ih_r =>
+      by_cases h1 : x < k
+      · by_cases h2 : k < x
+        · exfalso
+          exact (lt_asymm h1 h2)
+        · -- x < k (and not k < x)
+          cases hl' : insert x p l with
+          | nil =>
+              exfalso
+              exact insert_ne_nil x p l hl'
+          | node b pb lb rb =>
+              have hlkey : keys (node b pb lb rb) = Insert.insert x (keys l) := by
+                rw [← hl']
+                exact ih_l
+              by_cases hrot : pb > pk
+              · simp [insert, h1, hl', hrot]
+                rw [keys_rotR]
+                ext y
+                change y ∈ Insert.insert k (keys (node b pb lb rb) ∪ keys r) ↔
+                       y ∈ Insert.insert x (Insert.insert k (keys l ∪ keys r))
+                rw [hlkey]
+                simp [Finset.mem_insert, Finset.mem_union, or_assoc, or_left_comm, or_comm]
+              · simp [insert, h1, hl', hrot]
+                ext y
+                change y ∈ Insert.insert k (keys (node b pb lb rb) ∪ keys r) ↔
+                       y ∈ Insert.insert x (Insert.insert k (keys l ∪ keys r))
+                rw [hlkey]
+                simp [Finset.mem_insert, Finset.mem_union, or_assoc, or_left_comm, or_comm]
+      · by_cases h2 : k < x
+        · -- k < x
+          cases hr' : insert x p r with
+          | nil =>
+              exfalso
+              exact insert_ne_nil x p r hr'
+          | node b pb lb rb =>
+              have hrkey : keys (node b pb lb rb) = Insert.insert x (keys r) := by
+                rw [← hr']
+                exact ih_r
+              by_cases hrot : pb > pk
+              · simp [insert, h1, h2, hr', hrot]
+                rw [keys_rotL]
+                ext y
+                change y ∈ Insert.insert k (keys l ∪ keys (node b pb lb rb)) ↔
+                       y ∈ Insert.insert x (Insert.insert k (keys l ∪ keys r))
+                rw [hrkey]
+                simp [Finset.mem_insert, Finset.mem_union, or_assoc, or_left_comm, or_comm]
+              · simp [insert, h1, h2, hr', hrot]
+                ext y
+                change y ∈ Insert.insert k (keys l ∪ keys (node b pb lb rb)) ↔
+                       y ∈ Insert.insert x (Insert.insert k (keys l ∪ keys r))
+                rw [hrkey]
+                simp [Finset.mem_insert, Finset.mem_union, or_assoc, or_left_comm, or_comm]
+        · -- x = k: insert keeps the node unchanged
+          have hxk : x = k := le_antisymm (le_of_not_gt h2) (le_of_not_gt h1)
+          simp [insert, h1, h2, hxk, keys, Finset.insert_idem]
+
+/-- A treap is a *binary search tree* when every key in the left subtree is
+smaller than the root and every key in the right subtree is larger, and this
+holds recursively. -/
+def IsBST [LinearOrder α] [DecidableEq α] : Treap α → Prop
+  | nil => True
+  | node k _ l r =>
+      IsBST l ∧ IsBST r ∧ (∀ y ∈ keys l, y < k) ∧ (∀ y ∈ keys r, k < y)
+
+/-- Right rotation preserves well-formedness (BST). -/
+theorem IsBST_rotR [LinearOrder α] [DecidableEq α] [DecidableLT α] {t : Treap α}
+    (h : IsBST t) : IsBST (rotR t) := by
+  cases t with
+  | nil => simpa [rotR] using h
+  | node a pa l r =>
+      cases l with
+      | nil => simpa [rotR] using h
+      | node b pb lb rb =>
+          rcases h with ⟨hl, hr, hlt, hgt⟩
+          rcases hl with ⟨hlb, hrb, hltb, hgtrb⟩
+          have hba : b < a := hlt b (by simp [keys])
+          simp [rotR]
+          refine ⟨hlb, ?_, hltb, ?_⟩
+          · -- IsBST (node a pa rb r)
+            refine ⟨hrb, hr, ?_, hgt⟩
+            intro y hy
+            exact hlt y (by simp [keys, hy])
+          · -- ∀ y ∈ keys (node a pa rb r), b < y
+            intro y hy
+            have hy' : y ∈ Insert.insert a (keys rb ∪ keys r) := by simpa [keys] using hy
+            by_cases hya : y = a
+            · rw [hya]; exact hba
+            · by_cases hyrb : y ∈ keys rb
+              · exact hgtrb y hyrb
+              · have hyr : y ∈ keys r := by simpa [hya, hyrb] using hy'
+                exact lt_trans hba (hgt y hyr)
+
+/-- Left rotation preserves well-formedness (BST). -/
+theorem IsBST_rotL [LinearOrder α] [DecidableEq α] [DecidableLT α] {t : Treap α}
+    (h : IsBST t) : IsBST (rotL t) := by
+  cases t with
+  | nil => simpa [rotL] using h
+  | node a pa l r =>
+      cases r with
+      | nil => simpa [rotL] using h
+      | node b pb lb rb =>
+          rcases h with ⟨hl, hr, hlt, hgt⟩
+          rcases hr with ⟨hlb, hrb, hltb, hgtrb⟩
+          have hab : a < b := hgt b (by simp [keys])
+          simp [rotL]
+          refine ⟨?_, hrb, ?_, hgtrb⟩
+          · -- IsBST (node a pa l lb)
+            refine ⟨hl, hlb, hlt, ?_⟩
+            intro y hy
+            exact hgt y (by simp [keys, hy])
+          · -- ∀ y ∈ keys (node a pa l lb), y < b
+            intro y hy
+            have hy' : y ∈ Insert.insert a (keys l ∪ keys lb) := by simpa [keys] using hy
+            by_cases hyb : y ∈ keys lb
+            · exact hltb y hyb
+            · by_cases hya : y = a
+              · rw [hya]; exact hab
+              · have hyl : y ∈ keys l := by simpa [hya, hyb] using hy'
+                exact lt_trans (hlt y hyl) hab
+
+/-- Inserting into a well-formed treap keeps it well-formed. -/
+theorem IsBST_insert [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p : Nat)
+    (t : Treap α) : IsBST t → IsBST (insert x p t) := by
+  induction t with
+  | nil => intro _; simp [insert, IsBST, keys]
+  | node k pk l r ih_l ih_r =>
+      intro h
+      rcases h with ⟨hl, hr, hlt, hgt⟩
+      by_cases h1 : x < k
+      · by_cases h2 : k < x
+        · exfalso
+          exact (lt_asymm h1 h2)
+        · cases hl' : insert x p l with
+          | nil => exfalso; exact insert_ne_nil x p l hl'
+          | node b pb lb rb =>
+              have hlbst : IsBST (node b pb lb rb) := by
+                rw [← hl']
+                exact ih_l hl
+              have hnew : IsBST (node k pk (node b pb lb rb) r) := by
+                refine ⟨hlbst, hr, ?_, hgt⟩
+                intro y hy
+                have hyins : y ∈ keys (insert x p l) := by rw [hl']; exact hy
+                have hykeys : y ∈ Insert.insert x (keys l) := by
+                  rw [keys_insert x p l] at hyins
+                  exact hyins
+                by_cases hyx : y = x
+                · rw [hyx]; exact h1
+                · exact hlt y (by simpa [hyx] using hykeys)
+              by_cases hrot : pb > pk
+              · have hrot' : IsBST (rotR (node k pk (node b pb lb rb) r)) := IsBST_rotR hnew
+                simpa [insert, h1, hl', hrot]
+              · simpa [insert, h1, hl', hrot]
+      · by_cases h2 : k < x
+        · cases hr' : insert x p r with
+          | nil => exfalso; exact insert_ne_nil x p r hr'
+          | node b pb lb rb =>
+              have hrbst : IsBST (node b pb lb rb) := by
+                rw [← hr']
+                exact ih_r hr
+              have hnew : IsBST (node k pk l (node b pb lb rb)) := by
+                refine ⟨hl, hrbst, hlt, ?_⟩
+                intro y hy
+                have hyins : y ∈ keys (insert x p r) := by rw [hr']; exact hy
+                have hykeys : y ∈ Insert.insert x (keys r) := by
+                  rw [keys_insert x p r] at hyins
+                  exact hyins
+                by_cases hyx : y = x
+                · rw [hyx]; exact h2
+                · exact hgt y (by simpa [hyx] using hykeys)
+              by_cases hrot : pb > pk
+              · have hrot' : IsBST (rotL (node k pk l (node b pb lb rb))) := IsBST_rotL hnew
+                simpa [insert, h1, h2, hr', hrot]
+              · simpa [insert, h1, h2, hr', hrot]
+        · -- x = k: insert keeps the node unchanged
+          simp [insert, h1, h2]
+          exact ⟨hl, hr, hlt, hgt⟩
+
+/-- In a well-formed treap, the guided search agrees with set membership. -/
+theorem member_iff_keys [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) :
+    ∀ t : Treap α, IsBST t → (member x t = true ↔ x ∈ keys t) := by
+  intro t
+  induction t with
+  | nil => simp [member, keys]
+  | node k pk l r ih_l ih_r =>
+      intro h
+      rcases h with ⟨hl, hr, hlt, hgt⟩
+      by_cases hx : x = k
+      · simp [member, keys, hx]
+      · have hxne : x ≠ k := hx
+        by_cases hxlt : x < k
+        · have hxnr : x ∉ keys r := by
+            intro hxr
+            exact (lt_asymm hxlt (hgt x hxr))
+          simp [member, hxne, hxlt]
+          rw [ih_l hl]
+          simp [keys, hxne, hxnr]
+        · have hxnl : x ∉ keys l := by
+            intro hxl
+            exact hxlt (hlt x hxl)
+          simp [member, hxne, hxlt]
+          rw [ih_r hr]
+          simp [keys, hxne, hxnl]
+
+/-- **Target (proved).**  Membership of {lit}`insert x p t` is the old
+membership together with the new key, for well-formed treaps. -/
+theorem member_insert [LinearOrder α] [DecidableEq α] [DecidableLT α] (y x : α) (p : Nat)
+    (t : Treap α) (h : IsBST t) :
+    member y (insert x p t) = true ↔ member y t = true ∨ y = x := by
+  rw [member_iff_keys y (insert x p t) (IsBST_insert x p t h), keys_insert,
+    member_iff_keys y t h]
+  simp [Finset.mem_insert, or_assoc, or_left_comm, or_comm]
+
+/-- **Target (proved).**  Inserting {lit}`x` and then searching for it always
+finds it, for well-formed treaps. -/
+theorem insert_member [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p : Nat)
+    (t : Treap α) (h : IsBST t) : member x (insert x p t) = true := by
+  rw [member_iff_keys x (insert x p t) (IsBST_insert x p t h), keys_insert]
+  exact Finset.mem_insert_self x (keys t)
+
+end Treap
+
+end CLRS.Extensions

--- a/CLRSLean/Extensions/RandomizedTreap.lean
+++ b/CLRSLean/Extensions/RandomizedTreap.lean
@@ -741,6 +741,180 @@ theorem IsHeap_rotL [LinearOrder α] [DecidableEq α] [DecidableLT α] {a b : α
         rw [hprio]
         exact le_trans (prioOf_le_of_prioLE hpa_lb y) hpb
 
+/-- In a max-heap treap, if the root priority is at most {lit}`c` then every
+priority is at most {lit}`c`. -/
+theorem prioLE_of_heap_root_le [LinearOrder α] [DecidableEq α] [DecidableLT α]
+    {b : α} {pb c : Nat} {lb rb : Treap α}
+    (hheap : IsHeap (node b pb lb rb)) (hpb : pb ≤ c) :
+    prioLE c (node b pb lb rb) := by
+  rcases hheap with ⟨hlb, hrb, hpb_lb, hpb_rb⟩
+  unfold prioLE
+  intro y hy
+  have hy' : y ∈ Insert.insert b (keys lb ∪ keys rb) := by simpa [keys] using hy
+  by_cases hyb : y = b
+  · rw [hyb]
+    have hprio : prioOf (node b pb lb rb) b = pb := by simp [prioOf]
+    rw [hprio]
+    exact hpb
+  · by_cases hylt : y < b
+    · have hprio : prioOf (node b pb lb rb) y = prioOf lb y := by simp [prioOf, hyb, hylt]
+      rw [hprio]
+      exact le_trans (prioOf_le_of_prioLE hpb_lb y) hpb
+    · have hprio : prioOf (node b pb lb rb) y = prioOf rb y := by simp [prioOf, hyb, hylt]
+      rw [hprio]
+      exact le_trans (prioOf_le_of_prioLE hpb_rb y) hpb
+
+/-- **Capstone.**  Inserting into a well-formed (BST + heap) treap keeps it a
+valid treap: the single rotation along the insertion path repairs exactly the
+one heap violation. -/
+theorem IsHeap_insert [LinearOrder α] [DecidableEq α] [DecidableLT α] (x : α) (p : Nat)
+    (t : Treap α) : IsBST t → IsHeap t → IsHeap (insert x p t) := by
+  intro h hh
+  induction t with
+  | nil => simp [insert, IsHeap, prioLE, keys]
+  | node k pk l r ih_l ih_r =>
+      rcases h with ⟨hl, hr, hlt, hgt⟩
+      rcases hh with ⟨hhl, hhr, hpl, hpr⟩
+      by_cases h1 : x < k
+      · by_cases h2 : k < x
+        · exfalso
+          exact (lt_asymm h1 h2)
+        · -- x < k: insert into the left subtree
+          have hhl' : IsHeap (insert x p l) := ih_l hl hhl
+          cases hl' : insert x p l with
+          | nil => exfalso; exact insert_ne_nil x p l hl'
+          | node b pb lb rb =>
+              have hlbst' : IsBST (node b pb lb rb) := by rw [← hl']; exact IsBST_insert x p l hl
+              have hhl'' : IsHeap (node b pb lb rb) := by simpa [hl'] using hhl'
+              by_cases hrot : pb > pk
+              · -- rotation branch: the moved subtree rb stays bounded by pk
+                have hxnl : x ∉ keys l := by
+                  intro hxl
+                  have hdup : insert x p l = l := insert_of_mem_keys x p l hl hhl hxl
+                  rw [hdup] at hl'
+                  have hpb_pk : pb ≤ pk := by
+                    have hpb' : prioOf l b ≤ pk := hpl b (by simp [keys, hl'])
+                    simpa [hl', prioOf] using hpb'
+                  exact (not_lt_of_ge hpb_pk) hrot
+                have hbx : b = x := by
+                  have hb_mem' : b ∈ keys (insert x p l) := by rw [hl']; simp [keys]
+                  have hbmem : b ∈ Insert.insert x (keys l) := by
+                    rw [keys_insert x p l] at hb_mem'
+                    exact hb_mem'
+                  by_cases hbxl : b = x
+                  · exact hbxl
+                  · exfalso
+                    have hb_l : b ∈ keys l := by simpa [hbxl] using hbmem
+                    have hpb_eq : pb = prioOf l b := by
+                      have hpi : prioOf (insert x p l) b = if b = x then p else prioOf l b :=
+                        prioOf_insert x p l hl hxnl b
+                      have hpi' : prioOf (insert x p l) b = pb := by rw [hl']; simp [prioOf]
+                      rw [hpi'] at hpi
+                      simp [hbxl] at hpi
+                      exact hpi
+                    have hpb_pk : pb ≤ pk := by rw [hpb_eq]; exact hpl b hb_l
+                    exact (not_lt_of_ge hpb_pk) hrot
+                have hpk_rb : prioLE pk rb := by
+                  unfold prioLE
+                  intro z hz
+                  have hb_lt_z : b < z := hlbst'.2.2.2 z hz
+                  have hzx : z ≠ x := by
+                    intro hzx'
+                    have : x < x := by simp [hbx, hzx'] at hb_lt_z ⊢
+                    exact (lt_irrefl x this)
+                  have hzins : z ∈ keys (insert x p l) := by rw [hl']; simp [keys, hz]
+                  have hzkeys : z ∈ Insert.insert x (keys l) := by
+                    rw [keys_insert x p l] at hzins
+                    exact hzins
+                  have hzl : z ∈ keys l := by simpa [hzx] using hzkeys
+                  have hprio : prioOf rb z = prioOf l z := by
+                    have hpi : prioOf (insert x p l) z = if z = x then p else prioOf l z :=
+                      prioOf_insert x p l hl hxnl z
+                    have hpi' : prioOf (insert x p l) z = prioOf rb z := by
+                      rw [hl']
+                      have hzb : z ≠ b := ne_of_gt hb_lt_z
+                      have hznlt : ¬ z < b := not_lt_of_gt hb_lt_z
+                      simp [prioOf, hzb, hznlt]
+                    rw [hpi'] at hpi
+                    simp [hzx] at hpi
+                    exact hpi
+                  rw [hprio]
+                  exact hpl z hzl
+                simp [insert, h1, hl', hrot]
+                exact IsHeap_rotR hhl'' hhr (le_of_lt hrot) hpk_rb hpr
+              · -- no rotation: the root priority already bounds everything
+                simp [insert, h1, hl', hrot]
+                refine ⟨hhl'', hhr, prioLE_of_heap_root_le hhl'' (not_lt.mp hrot), hpr⟩
+      · by_cases h2 : k < x
+        · -- k < x: insert into the right subtree (symmetric)
+          have hhr' : IsHeap (insert x p r) := ih_r hr hhr
+          cases hr' : insert x p r with
+          | nil => exfalso; exact insert_ne_nil x p r hr'
+          | node b pb lb rb =>
+              have hrbst' : IsBST (node b pb lb rb) := by rw [← hr']; exact IsBST_insert x p r hr
+              have hhr'' : IsHeap (node b pb lb rb) := by simpa [hr'] using hhr'
+              by_cases hrot : pb > pk
+              · -- rotation branch: the moved subtree lb stays bounded by pk
+                have hxnr : x ∉ keys r := by
+                  intro hxr
+                  have hdup : insert x p r = r := insert_of_mem_keys x p r hr hhr hxr
+                  rw [hdup] at hr'
+                  have hpb_pk : pb ≤ pk := by
+                    have hpb' : prioOf r b ≤ pk := hpr b (by simp [keys, hr'])
+                    simpa [hr', prioOf] using hpb'
+                  exact (not_lt_of_ge hpb_pk) hrot
+                have hbx : b = x := by
+                  have hb_mem' : b ∈ keys (insert x p r) := by rw [hr']; simp [keys]
+                  have hbmem : b ∈ Insert.insert x (keys r) := by
+                    rw [keys_insert x p r] at hb_mem'
+                    exact hb_mem'
+                  by_cases hbxl : b = x
+                  · exact hbxl
+                  · exfalso
+                    have hb_r : b ∈ keys r := by simpa [hbxl] using hbmem
+                    have hpb_eq : pb = prioOf r b := by
+                      have hpi : prioOf (insert x p r) b = if b = x then p else prioOf r b :=
+                        prioOf_insert x p r hr hxnr b
+                      have hpi' : prioOf (insert x p r) b = pb := by rw [hr']; simp [prioOf]
+                      rw [hpi'] at hpi
+                      simp [hbxl] at hpi
+                      exact hpi
+                    have hpb_pk : pb ≤ pk := by rw [hpb_eq]; exact hpr b hb_r
+                    exact (not_lt_of_ge hpb_pk) hrot
+                have hpk_lb : prioLE pk lb := by
+                  unfold prioLE
+                  intro z hz
+                  have hz_lt_b : z < b := hrbst'.2.2.1 z hz
+                  have hzx : z ≠ x := by
+                    intro hzx'
+                    have : x < x := by simp [hbx, hzx'] at hz_lt_b ⊢
+                    exact (lt_irrefl x this)
+                  have hzins : z ∈ keys (insert x p r) := by rw [hr']; simp [keys, hz]
+                  have hzkeys : z ∈ Insert.insert x (keys r) := by
+                    rw [keys_insert x p r] at hzins
+                    exact hzins
+                  have hzr : z ∈ keys r := by simpa [hzx] using hzkeys
+                  have hprio : prioOf lb z = prioOf r z := by
+                    have hpi : prioOf (insert x p r) z = if z = x then p else prioOf r z :=
+                      prioOf_insert x p r hr hxnr z
+                    have hpi' : prioOf (insert x p r) z = prioOf lb z := by
+                      rw [hr']
+                      have hzb : z ≠ b := ne_of_lt hz_lt_b
+                      simp [prioOf, hzb, hz_lt_b]
+                    rw [hpi'] at hpi
+                    simp [hzx] at hpi
+                    exact hpi
+                  rw [hprio]
+                  exact hpr z hzr
+                simp [insert, h1, h2, hr', hrot]
+                exact IsHeap_rotL hhl hhr'' (le_of_lt hrot) hpk_lb hpl
+              · -- no rotation
+                simp [insert, h1, h2, hr', hrot]
+                refine ⟨hhl, hhr'', hpl, prioLE_of_heap_root_le hhr'' (not_lt.mp hrot)⟩
+        · -- x = k: duplicate, tree unchanged
+          simp [insert, h1, h2]
+          exact ⟨hhl, hhr, hpl, hpr⟩
+
 end Treap
 
 end CLRS.Extensions

--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -1,0 +1,90 @@
+import CLRSLean.Extensions.TreapRandom
+
+open CLRS.Probability
+open scoped BigOperators
+
+namespace CLRS.Extensions
+
+namespace Treap
+
+/-!
+# Randomized treap: expected height
+
+This module completes the treap analysis by bounding the expected **height**
+(the maximum depth over all keys), which is {lit}`O(log n)`.
+
+The depth of a single key was bounded in {lit}`TreapRandom` via its harmonic
+ancestor sum.  The height needs more: a bound on the *maximum* depth, which is
+obtained by an exponential tail on the depth of a single key.
+
+**Record structure.**  Walking left from key {lit}`b`, its left-ancestors are
+exactly the left-to-right record maxima of the priority sequence
+{lit}`(σ b, σ (b-1), …, σ 0)`.  In a random permutation the number of records
+has an exponential tail, so the depth does too, and a union bound over the keys
+turns it into an {lit}`O(log n)` expected-height bound.
+
+Main results (targets):
+
+- Theorem {lit}`height_le_harmonic`: {lit}`E[height] ≤ c · H_n` for an explicit
+  constant {lit}`c`.
+
+Status: prototype, not registered in {lit}`literate.toml`.
+-/
+
+/-- The left-ancestors of key {lit}`b`: keys strictly below {lit}`b` that are
+ancestors of {lit}`b`. -/
+noncomputable def leftAncestors {n : ℕ} (σ : PrioPerm n) (b : Fin n) : ℕ :=
+  (Finset.univ.filter (fun a : Fin n => a < b ∧ Ancestor σ a b)).card
+
+/-- The right-ancestors of key {lit}`b`: keys strictly above {lit}`b` that are
+ancestors of {lit}`b`. -/
+noncomputable def rightAncestors {n : ℕ} (σ : PrioPerm n) (b : Fin n) : ℕ :=
+  (Finset.univ.filter (fun a : Fin n => b < a ∧ Ancestor σ a b)).card
+
+/-- The depth of {lit}`b` counts its left-ancestors, itself, and its
+right-ancestors. -/
+lemma depth_eq_left_add_right {n : ℕ} (σ : PrioPerm n) (b : Fin n) :
+    depth σ b = leftAncestors σ b + rightAncestors σ b + 1 := by
+  classical
+  have hpt : ∀ a : Fin n, (if Ancestor σ a b then 1 else 0) =
+      (if a < b ∧ Ancestor σ a b then 1 else 0) + (if a = b then 1 else 0) +
+        (if b < a ∧ Ancestor σ a b then 1 else 0) := by
+    intro a
+    by_cases hne : a = b
+    · subst a; simp [Ancestor]
+    · have hltgt : a < b ∨ b < a := lt_or_gt_of_ne hne
+      rcases hltgt with hlt | hgt
+      · have hb_lt : ¬ b < a := not_lt.mpr (le_of_lt hlt)
+        have ha_ne : ¬ a = b := ne_of_lt hlt
+        simp [hlt, hb_lt, ha_ne]
+      · have ha_lt : ¬ a < b := not_lt.mpr (le_of_lt hgt)
+        have ha_ne : ¬ a = b := ne_of_gt hgt
+        simp [hgt, ha_lt, ha_ne]
+  calc
+    depth σ b = (∑ a : Fin n, if Ancestor σ a b then 1 else 0) := by
+      unfold depth
+      rw [Finset.card_filter]
+    _ = (∑ a : Fin n, ((if a < b ∧ Ancestor σ a b then 1 else 0) + (if a = b then 1 else 0) +
+          (if b < a ∧ Ancestor σ a b then 1 else 0))) := by
+          apply Finset.sum_congr rfl
+          intro a ha
+          exact hpt a
+    _ = (∑ a : Fin n, if a < b ∧ Ancestor σ a b then 1 else 0) + 1 +
+        (∑ a : Fin n, if b < a ∧ Ancestor σ a b then 1 else 0) := by
+          simp [Finset.sum_add_distrib, Finset.sum_ite_eq']
+    _ = leftAncestors σ b + rightAncestors σ b + 1 := by
+          unfold leftAncestors rightAncestors
+          rw [Finset.card_filter, Finset.card_filter]
+          ring
+
+/-- The height of the treap under {lit}`σ`: the maximum depth over all keys. -/
+noncomputable def treapHeight {n : ℕ} (σ : PrioPerm n) : ℕ :=
+  (Finset.univ.sup (fun b : Fin n => depth σ b))
+
+/-- The expected height under a uniform random priority permutation. -/
+noncomputable def expectedTreapHeight {n : ℕ} : ℝ :=
+  fintypeExpect (fun σ : PrioPerm n => (treapHeight σ : ℝ))
+
+end Treap
+
+end CLRS.Extensions

--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -10,8 +10,8 @@ namespace Treap
 /-!
 # Randomized treap: expected height
 
-This module completes the treap analysis by bounding the expected **height**
-(the maximum depth over all keys), which is {lit}`O(log n)`.
+This module develops the next proof layer toward bounding the expected
+**height** (the maximum depth over all keys) by {lit}`O(log n)`.
 
 The depth of a single key was bounded in {lit}`TreapRandom` via its harmonic
 ancestor sum.  The height needs more: a bound on the *maximum* depth, which is
@@ -23,12 +23,14 @@ exactly the left-to-right record maxima of the priority sequence
 has an exponential tail, so the depth does too, and a union bound over the keys
 turns it into an {lit}`O(log n)` expected-height bound.
 
-Main results (targets):
+Main result (target, not yet proved):
 
 - Theorem {lit}`height_le_harmonic`: {lit}`E[height] ≤ c · H_n` for an explicit
   constant {lit}`c`.
 
-Status: prototype, not registered in {lit}`literate.toml`.
+Status: prototype, not registered in {lit}`literate.toml`.  The depth
+decomposition and left-ancestor product formula are kernel-checked; the
+exponential-tail and final expected-height bounds remain future work.
 -/
 
 /-- The left-ancestors of key {lit}`b`: keys strictly below {lit}`b` that are

--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -85,6 +85,198 @@ noncomputable def treapHeight {n : ℕ} (σ : PrioPerm n) : ℕ :=
 noncomputable def expectedTreapHeight {n : ℕ} : ℝ :=
   fintypeExpect (fun σ : PrioPerm n => (treapHeight σ : ℝ))
 
+/-! ## Exponential tail on the depth -/
+
+/-- Right-multiplication by a transposition is a bijection on `PrioPerm n`; it
+swaps the priorities carried by the keys `c` and `t`. -/
+lemma swapComp'_bijective {c t : Fin n} :
+    Function.Bijective (fun (σ : PrioPerm n) => σ * (Equiv.swap c t)) := by
+  constructor
+  · intro σ₁ σ₂ h
+    apply_fun (fun φ : PrioPerm n => φ * (Equiv.swap c t)) at h
+    simpa [mul_assoc] using h
+  · intro σ
+    refine ⟨σ * (Equiv.swap c t), ?_⟩
+    simp [mul_assoc]
+
+/-- Swapping the priorities carried by the keys `c` and `t` (neither of which is
+the leader `a`) preserves `a` carrying the maximum priority of `I`. -/
+lemma maxOver_swap_key {n : ℕ} {I : Finset (Fin n)} {a c t : Fin n} (σ : PrioPerm n)
+    (hca : c ≠ a) (hta : t ≠ a) (hcI : c ∈ I) (htI : t ∈ I)
+    (hmax : MaxOver σ I a) :
+    MaxOver (σ * (Equiv.swap c t)) I a := by
+  rcases hmax with ⟨haI, hle⟩
+  refine ⟨haI, ?_⟩
+  intro k hkI
+  have hswapa : Equiv.swap c t a = a := Equiv.swap_apply_of_ne_of_ne (Ne.symm hca) (Ne.symm hta)
+  have ha' : prioOfPerm (σ * (Equiv.swap c t)) a = prioOfPerm σ a := by
+    unfold prioOfPerm
+    rw [Equiv.Perm.mul_apply, hswapa]
+  rw [ha']
+  have hk' : prioOfPerm (σ * (Equiv.swap c t)) k = prioOfPerm σ (Equiv.swap c t k) := by
+    unfold prioOfPerm
+    rw [Equiv.Perm.mul_apply]
+  rw [hk']
+  by_cases hkc : k = c
+  · subst k
+    rw [Equiv.swap_apply_left]
+    exact hle t htI
+  · by_cases hkt : k = t
+    · subst k
+      rw [Equiv.swap_apply_right]
+      exact hle c hcI
+    · have hk'' : Equiv.swap c t k = k := Equiv.swap_apply_of_ne_of_ne hkc hkt
+      rw [hk'']
+      exact hle k hkI
+
+/-- Swapping the priorities carried by `c` and `t` moves the maximum priority of
+`U` from `c` to `t` (both in `U`). -/
+lemma maxOver_swap_max {n : ℕ} {U : Finset (Fin n)} {c t : Fin n} (σ : PrioPerm n)
+    (hcU : c ∈ U) (htU : t ∈ U) (hmax : MaxOver σ U c) :
+    MaxOver (σ * (Equiv.swap c t)) U t := by
+  rcases hmax with ⟨hcU', hle⟩
+  refine ⟨htU, ?_⟩
+  intro k hkU
+  have ht' : prioOfPerm (σ * (Equiv.swap c t)) t = prioOfPerm σ c := by
+    unfold prioOfPerm
+    rw [Equiv.Perm.mul_apply, Equiv.swap_apply_right]
+  rw [ht']
+  have hk' : prioOfPerm (σ * (Equiv.swap c t)) k = prioOfPerm σ (Equiv.swap c t k) := by
+    unfold prioOfPerm
+    rw [Equiv.Perm.mul_apply]
+  rw [hk']
+  by_cases hkc : k = c
+  · subst k
+    rw [Equiv.swap_apply_left]
+    exact hle t htU
+  · by_cases hkt : k = t
+    · subst k
+      rw [Equiv.swap_apply_right]
+    · have hk'' : Equiv.swap c t k = k := Equiv.swap_apply_of_ne_of_ne hkc hkt
+      rw [hk'']
+      exact hle k hkU
+
+/-- Given that all keys of `T` are left-ancestors of `b` (with every `a ∈ T`
+strictly below `c`), the maximum priority of `Icc c b` is equally likely to sit
+at any of its keys.  Counted: the `c`-max events have one `|Icc c b|`-th of the
+mass of the `T`-max events. -/
+lemma maxExtend_uniform {n : ℕ} {b : Fin n} (T : Finset (Fin n)) {c : Fin n}
+    (hT : ∀ a ∈ T, a < c) (hc : c < b) :
+    ((Finset.univ.filter (fun σ : PrioPerm n =>
+        (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) ∧ MaxOver σ (Finset.Icc c b) c)).card) *
+      (Finset.Icc c b).card =
+    (Finset.univ.filter (fun σ : PrioPerm n =>
+        ∀ a ∈ T, MaxOver σ (Finset.Icc a b) a)).card := by
+  classical
+  let U : Finset (Fin n) := Finset.Icc c b
+  have hcU : c ∈ U := by dsimp [U]; exact Finset.mem_Icc.mpr ⟨le_rfl, le_of_lt hc⟩
+  -- For each a ∈ T, the swap of {a}∪{c,t}... build the "all T maxima preserved" helper.
+  have hTswap : ∀ (a : Fin n), a ∈ T → ∀ (t : Fin n), t ∈ U →
+      ∀ (σ : PrioPerm n), MaxOver σ (Finset.Icc a b) a →
+        MaxOver (σ * (Equiv.swap c t)) (Finset.Icc a b) a := by
+    intro a haT t htU σ hmax
+    have hac : a < c := hT a haT
+    have hca' : c ≠ a := ne_of_gt hac
+    have hta' : t ≠ a := ne_of_gt (lt_of_lt_of_le hac (Finset.mem_Icc.mp htU).1)
+    have haI : a ∈ Finset.Icc a b := Finset.mem_Icc.mpr ⟨le_rfl, le_of_lt (lt_trans hac hc)⟩
+    have hcI : c ∈ Finset.Icc a b := Finset.mem_Icc.mpr ⟨le_of_lt hac, le_of_lt hc⟩
+    have htI : t ∈ Finset.Icc a b := by
+      rw [Finset.mem_Icc] at htU
+      exact Finset.mem_Icc.mpr ⟨le_trans (le_of_lt hac) htU.1, htU.2⟩
+    exact maxOver_swap_key σ hca' hta' hcI htI hmax
+  -- Step 1: for each t ∈ U, the events {t = max of U} within {all T maxima} are equiprobable
+  -- via the swap c t bijection.
+  have hEq : ∀ t ∈ U, (Finset.univ.filter (fun σ : PrioPerm n =>
+        (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) ∧ MaxOver σ U t)).card =
+      (Finset.univ.filter (fun σ : PrioPerm n =>
+        (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) ∧ MaxOver σ U c)).card := by
+    intro t htU
+    apply Finset.card_bij (fun σ _ => σ * (Equiv.swap c t))
+    · -- maps the t-set into the c-set
+      intro σ hσ
+      rw [Finset.mem_filter] at hσ
+      rcases hσ with ⟨hσu, ⟨hTσ, htmax⟩⟩
+      refine Finset.mem_filter.mpr ⟨Finset.mem_univ _, ?_⟩
+      constructor
+      · intro a haT
+        exact hTswap a haT t htU σ (hTσ a haT)
+      · -- c is the max of U under σ * swap ct
+        have hc' : MaxOver (σ * (Equiv.swap c t)) U c := by
+          simpa [Equiv.swap_comm] using maxOver_swap_max (c := t) (t := c) σ htU hcU htmax
+        exact hc'
+    · -- injectivity
+      intro σ₁ hσ₁ σ₂ hσ₂ h
+      exact (swapComp'_bijective (c := c) (t := t)).1 h
+    · -- surjectivity onto the c-set
+      intro σ hσ
+      rw [Finset.mem_filter] at hσ
+      rcases hσ with ⟨hσu, ⟨hTσ, hcmax⟩⟩
+      refine ⟨σ * (Equiv.swap c t), ?_, ?_⟩
+      · refine Finset.mem_filter.mpr ⟨Finset.mem_univ _, ?_⟩
+        constructor
+        · intro a haT
+          exact hTswap a haT t htU σ (hTσ a haT)
+        · -- t is the max of U under σ * swap ct
+          exact maxOver_swap_max σ hcU htU hcmax
+      · -- σ * swap * swap = σ
+        simpa [mul_assoc]
+  -- Step 2: the {t = max of U} events partition {all T maxima}.
+  have hcover : (Finset.univ.filter (fun σ : PrioPerm n =>
+        ∀ a ∈ T, MaxOver σ (Finset.Icc a b) a)) =
+      Finset.biUnion U (fun t => Finset.univ.filter (fun σ : PrioPerm n =>
+        (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) ∧ MaxOver σ U t)) := by
+    apply Finset.Subset.antisymm
+    · intro σ hσ
+      rw [Finset.mem_filter] at hσ
+      rcases hσ with ⟨hσu, hTσ⟩
+      -- the max of U under σ is at some t ∈ U
+      have hmaxU : ∃ t ∈ U, MaxOver σ U t := by
+        have hUne : U.Nonempty := ⟨c, hcU⟩
+        rcases Finset.exists_max_image U (prioOfPerm σ) hUne with ⟨m, hmU, hmax⟩
+        refine ⟨m, hmU, ?_⟩
+        exact ⟨hmU, hmax⟩
+      rcases hmaxU with ⟨t, htU, htmax⟩
+      apply Finset.mem_biUnion.mpr
+      exact ⟨t, htU, Finset.mem_filter.mpr ⟨Finset.mem_univ _, ⟨hTσ, htmax⟩⟩⟩
+    · intro σ hσ
+      rw [Finset.mem_biUnion] at hσ
+      rcases hσ with ⟨t, htU, hσt⟩
+      rw [Finset.mem_filter] at hσt
+      exact Finset.mem_filter.mpr ⟨hσt.1, hσt.2.1⟩
+  -- Step 3: the {t = max of U} sets are pairwise disjoint
+  have hdisj : ∀ t₁ ∈ U, ∀ t₂ ∈ U, t₁ ≠ t₂ →
+      Disjoint (Finset.univ.filter (fun σ : PrioPerm n =>
+          (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) ∧ MaxOver σ U t₁))
+               (Finset.univ.filter (fun σ : PrioPerm n =>
+          (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) ∧ MaxOver σ U t₂)) := by
+    intro t₁ ht₁ t₂ ht₂ hne
+    apply Finset.disjoint_filter.2
+    intro σ _ h₁ h₂
+    -- MaxOver σ U t₁ and MaxOver σ U t₂ imply t₁ = t₂ (unique max)
+    have hu1 : MaxOver σ U t₁ := h₁.2
+    have hu2 : MaxOver σ U t₂ := h₂.2
+    -- uniqueness: MaxOver U t₁ ∧ MaxOver U t₂ → t₁ = t₂
+    have ht1t2 : t₁ = t₂ := by
+      have h12 : (σ t₂).1 ≤ (σ t₁).1 := hu1.2 t₂ ht₂
+      have h21 : (σ t₁).1 ≤ (σ t₂).1 := hu2.2 t₁ ht₁
+      have heq : (σ t₁).1 = (σ t₂).1 := le_antisymm h21 h12
+      exact σ.injective (Fin.ext heq)
+    exact hne ht1t2
+  calc
+    ((Finset.univ.filter (fun σ : PrioPerm n =>
+        (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) ∧ MaxOver σ U c)).card) * U.card
+        = (∑ t ∈ U, (Finset.univ.filter (fun σ : PrioPerm n =>
+            (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) ∧ MaxOver σ U t)).card) := by
+          rw [Finset.sum_congr rfl (fun t ht => hEq t ht)]
+          rw [Finset.sum_const]
+          simp [nsmul_eq_mul, mul_comm]
+    _ = (Finset.biUnion U (fun t => Finset.univ.filter (fun σ : PrioPerm n =>
+          (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) ∧ MaxOver σ U t))).card := by
+          rw [← Finset.card_biUnion]
+          · exact hdisj
+    _ = (Finset.univ.filter (fun σ : PrioPerm n =>
+          ∀ a ∈ T, MaxOver σ (Finset.Icc a b) a)).card := by rw [hcover]
+
 end Treap
 
 end CLRS.Extensions

--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -277,6 +277,100 @@ lemma maxExtend_uniform {n : ℕ} {b : Fin n} (T : Finset (Fin n)) {c : Fin n}
     _ = (Finset.univ.filter (fun σ : PrioPerm n =>
           ∀ a ∈ T, MaxOver σ (Finset.Icc a b) a)).card := by rw [hcover]
 
+lemma leftAncestors_product {n : ℕ} {b : Fin n} (S : Finset (Fin n))
+    (hS : ∀ a ∈ S, a < b) :
+    ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)).card : ℝ) =
+      (Fintype.card (PrioPerm n) : ℝ) * ∏ a ∈ S, (1 / ((Finset.Icc a b).card : ℝ)) := by
+  classical
+  have hIH : ∀ m : ℕ, ∀ S : Finset (Fin n), S.card = m → (∀ a ∈ S, a < b) →
+      ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)).card : ℝ) =
+        (Fintype.card (PrioPerm n) : ℝ) * ∏ a ∈ S, (1 / ((Finset.Icc a b).card : ℝ)) := by
+    intro m
+    induction m with
+    | zero =>
+        intro S hcard hS
+        have hSempty : S = ∅ := (Finset.card_eq_zero.mp hcard)
+        subst S
+        simp
+    | succ m ih =>
+        intro S hcard hS
+        by_cases hempty : S = ∅
+        · subst S
+          simp
+        · have hSne : S.Nonempty := Finset.nonempty_iff_ne_empty.mpr hempty
+          let c : Fin n := S.max' hSne
+          have hcS : c ∈ S := Finset.max'_mem S hSne
+          have hcb : c < b := hS c hcS
+          have hothers : ∀ a ∈ S.erase c, a < c := by
+            intro a ha
+            rw [Finset.mem_erase] at ha
+            have hle : a ≤ c := Finset.le_max' S a ha.2
+            exact lt_of_le_of_ne hle ha.1
+          have hSsplit : Insert.insert c (S.erase c) = S := Finset.insert_erase hcS
+          have hcard2 : (S.erase c).card = m := by
+            have : (S.erase c).card = S.card - 1 := Finset.card_erase_of_mem hcS
+            omega
+          have hS2 : ∀ a ∈ S.erase c, a < b := by
+            intro a ha
+            rw [Finset.mem_erase] at ha
+            exact hS a ha.2
+          have hme := maxExtend_uniform (S.erase c) hothers hcb
+          have hSsplit' : S = Insert.insert c (S.erase c) := hSsplit.symm
+          have hcardId : (Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)).card *
+              (Finset.Icc c b).card =
+            (Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S.erase c, MaxOver σ (Finset.Icc a b) a)).card := by
+            have hSetEq : (Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)) =
+                (Finset.univ.filter (fun σ : PrioPerm n => (∀ a ∈ S.erase c, MaxOver σ (Finset.Icc a b) a) ∧
+                  MaxOver σ (Finset.Icc c b) c)) := by
+              ext σ
+              simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+              constructor
+              · intro h
+                constructor
+                · intro a ha
+                  rw [Finset.mem_erase] at ha
+                  exact h a ha.2
+                · exact h c hcS
+              · intro h
+                intro a ha
+                by_cases hac : a = c
+                · subst a
+                  exact h.2
+                · exact h.1 a (Finset.mem_erase.mpr ⟨hac, ha⟩)
+            rw [hSetEq]
+            simpa using hme
+          have hcn0 : ((Finset.Icc c b).card : ℝ) ≠ 0 := by
+            have hpos : 0 < (Finset.Icc c b).card := by
+              have : c ∈ Finset.Icc c b := Finset.mem_Icc.mpr ⟨le_rfl, le_of_lt hcb⟩
+              exact Finset.card_pos.mpr ⟨c, this⟩
+            exact_mod_cast (ne_of_gt hpos)
+          -- hcardId: |{all S}|·|[c,b]| = |{all S.erase c}|
+          -- so |{all S}| = |{all S.erase c}|/|[c,b]|
+          have hdiv : ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)).card : ℝ) =
+              ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S.erase c, MaxOver σ (Finset.Icc a b) a)).card : ℝ) /
+                ((Finset.Icc c b).card : ℝ) := by
+            have hcardId' : ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)).card : ℝ) *
+                ((Finset.Icc c b).card : ℝ) =
+              ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S.erase c, MaxOver σ (Finset.Icc a b) a)).card : ℝ) := by
+              exact_mod_cast hcardId
+            exact (eq_div_iff hcn0).mpr hcardId'
+          calc
+            ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)).card : ℝ)
+                = ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S.erase c, MaxOver σ (Finset.Icc a b) a)).card : ℝ) *
+                    (1 / ((Finset.Icc c b).card : ℝ)) := by
+                  rw [hdiv]
+                  ring
+            _ = (Fintype.card (PrioPerm n) : ℝ) * (∏ a ∈ S.erase c, (1 / ((Finset.Icc a b).card : ℝ))) *
+                  (1 / ((Finset.Icc c b).card : ℝ)) := by
+                  rw [ih (S.erase c) hcard2 hS2]
+            _ = (Fintype.card (PrioPerm n) : ℝ) * (∏ a ∈ S, (1 / ((Finset.Icc a b).card : ℝ))) := by
+                  rw [← hSsplit]
+                  rw [Finset.prod_insert]
+                  · rw [Finset.erase_insert (by simp)]
+                    ring
+                  · simp
+  exact hIH S.card S rfl hS
+
 end Treap
 
 end CLRS.Extensions

--- a/CLRSLean/Extensions/TreapRandom.lean
+++ b/CLRSLean/Extensions/TreapRandom.lean
@@ -1,0 +1,96 @@
+import CLRSLean.Extensions.RandomizedTreap
+import CLRSLean.Probability.FiniteExpectation
+import Mathlib.Tactic
+
+open CLRS.Probability
+
+/-!
+# Randomized treap: expected depth (prototype)
+
+This module analyzes the *probabilistic* side of the treap.  With `n` keys and
+uniformly random distinct priorities, the canonical treap (root = maximum
+priority, recurse on the two halves) has expected height `O(log n)`.  The
+first milestone proved here is the expected **depth** of a single key, which is
+the probabilistic core.
+
+**Model.**  Keys are `Fin n`.  A random priority assignment is a uniform random
+permutation `σ : Fin n ≃ Fin n` (the sample space is `Equiv.Perm (Fin n)`), and
+the priority of key `i` is `σ i`.  The combinatorial characterization that ties
+the analysis to the treap shape is: for `a ≠ b`, key `a` is an **ancestor** of
+key `b` in the canonical treap iff `a` has the maximum priority among the keys
+in the closed interval `[min a b, max a b]` — the maximum-priority key in an
+interval is exactly the key that sits on the path from the root to `b`.
+
+Consequently `depth b` is the number of ancestors of `b`, and by linearity of
+expectation the expected depth is
+
+> `E[depth b] = 1 + Σ_{a ≠ b} 1 / (|a - b| + 1)`
+
+because among the `k = |a - b| + 1` keys of the interval, each is equally
+likely to carry the maximum priority.  The right-hand side is a pair of
+harmonic sums, so `E[depth b] ≤ 2 · H_n = O(log n)`.
+
+Main results (targets):
+
+- Theorem `ancestor_prob`: `P[a ancestor of b] = 1 / (|a - b| + 1)` for `a ≠ b`.
+- Theorem `expectedDepth_le_harmonic`: `E[depth b] ≤ 2 · H_n` (once harmonic
+  numbers are imported or stated).
+
+Status: prototype.  The model and the reduction of the expectation to the
+ancestor probabilities are below; the ancestor-probability counting and the
+harmonic bound are the current targets.  Not registered in `literate.toml`.
+-/
+
+namespace CLRS.Extensions
+
+namespace Treap
+
+open scoped BigOperators
+
+/-- Keys are `Fin n`; `n` is the number of keys. -/
+abbrev Key (n : ℕ) := Fin n
+
+/-- A random priority assignment: a permutation of the keys' priorities.
+Key `i` gets priority `σ i`. -/
+abbrev PrioPerm (n : ℕ) := Equiv.Perm (Fin n)
+
+/-- The priority of key `i` under the permutation `σ`, as a natural. -/
+def prioOfPerm {n : ℕ} (σ : PrioPerm n) (i : Fin n) : ℕ := (σ i).1
+
+/-- Key `a` is an *ancestor* of key `b` in the canonical treap under priority
+order `σ`: every key, and for `a ≠ b`, `a` carries the maximum priority among
+the keys in the closed interval between `a` and `b`. -/
+def Ancestor {n : ℕ} (σ : PrioPerm n) (a b : Fin n) : Prop :=
+  a = b ∨ ∀ k ∈ Finset.Icc (min a b) (max a b), prioOfPerm σ k ≤ prioOfPerm σ a
+
+instance instDecidableAncestor {n : ℕ} (σ : PrioPerm n) (a b : Fin n) :
+    Decidable (Ancestor σ a b) := by
+  unfold Ancestor
+  infer_instance
+
+/-- The depth of key `b` in the canonical treap under `σ`: the number of keys
+that are ancestors of `b`. -/
+noncomputable def depth {n : ℕ} (σ : PrioPerm n) (b : Fin n) : ℕ := by
+  classical
+  exact (Finset.univ.filter (fun a : Fin n => Ancestor σ a b)).card
+
+/-- The expected depth of key `b` under a uniform random priority permutation. -/
+noncomputable def expectedDepth {n : ℕ} (b : Fin n) : ℝ :=
+  fintypeExpect (fun σ : PrioPerm n => (depth σ b : ℝ))
+
+/-- Depth counts ancestors, so by linearity of expectation the expected depth
+is the sum over keys of the probability that the key is an ancestor of `b`. -/
+theorem expectedDepth_eq_sum {n : ℕ} (b : Fin n) :
+    expectedDepth b =
+      ∑ a : Fin n, fintypeExpect (fun σ : PrioPerm n => indicator (Ancestor σ a b)) := by
+  unfold expectedDepth
+  have hred : (fun σ : PrioPerm n => (depth σ b : ℝ)) =
+      fun σ : PrioPerm n => ∑ a : Fin n, indicator (Ancestor σ a b) := by
+    funext σ
+    simp [depth, indicator]
+  rw [hred]
+  rw [fintypeExpect_sum]
+
+end Treap
+
+end CLRS.Extensions

--- a/CLRSLean/Extensions/TreapRandom.lean
+++ b/CLRSLean/Extensions/TreapRandom.lean
@@ -7,38 +7,41 @@ open CLRS.Probability
 /-!
 # Randomized treap: expected depth (prototype)
 
-This module analyzes the *probabilistic* side of the treap.  With `n` keys and
-uniformly random distinct priorities, the canonical treap (root = maximum
-priority, recurse on the two halves) has expected height `O(log n)`.  The
-first milestone proved here is the expected **depth** of a single key, which is
-the probabilistic core.
+This module analyzes the *probabilistic* side of the treap.  With
+{lit}`n` keys and uniformly random distinct priorities, the canonical treap
+(root = maximum priority, recurse on the two halves) has expected height
+{lit}`O(log n)`.  The first milestone proved here is the expected **depth** of
+a single key, which is the probabilistic core.
 
-**Model.**  Keys are `Fin n`.  A random priority assignment is a uniform random
-permutation `σ : Fin n ≃ Fin n` (the sample space is `Equiv.Perm (Fin n)`), and
-the priority of key `i` is `σ i`.  The combinatorial characterization that ties
-the analysis to the treap shape is: for `a ≠ b`, key `a` is an **ancestor** of
-key `b` in the canonical treap iff `a` has the maximum priority among the keys
-in the closed interval `[min a b, max a b]` — the maximum-priority key in an
-interval is exactly the key that sits on the path from the root to `b`.
+**Model.**  Keys are {lit}`Fin n`.  A random priority assignment is a uniform
+random permutation {lit}`σ : Fin n ≃ Fin n` (the sample space is
+{lit}`Equiv.Perm (Fin n)`), and the priority of key {lit}`i` is {lit}`σ i`.
+The combinatorial characterization that ties the analysis to the treap shape
+is: for {lit}`a ≠ b`, key {lit}`a` is an **ancestor** of key {lit}`b` in the
+canonical treap iff {lit}`a` has the maximum priority among the keys in the
+closed interval {lit}`[min a b, max a b]` — the maximum-priority key in an
+interval is exactly the key that sits on the path from the root to {lit}`b`.
 
-Consequently `depth b` is the number of ancestors of `b`, and by linearity of
-expectation the expected depth is
+Consequently {lit}`depth b` is the number of ancestors of {lit}`b`, and by
+linearity of expectation the expected depth is
 
-> `E[depth b] = 1 + Σ_{a ≠ b} 1 / (|a - b| + 1)`
+> {lit}`E[depth b] = 1 + Σ_{a ≠ b} 1 / (|a - b| + 1)`
 
-because among the `k = |a - b| + 1` keys of the interval, each is equally
+because among the {lit}`k = |a - b| + 1` keys of the interval, each is equally
 likely to carry the maximum priority.  The right-hand side is a pair of
-harmonic sums, so `E[depth b] ≤ 2 · H_n = O(log n)`.
+harmonic sums, so {lit}`E[depth b] ≤ 2 · H_n = O(log n)`.
 
 Main results (targets):
 
-- Theorem `ancestor_prob`: `P[a ancestor of b] = 1 / (|a - b| + 1)` for `a ≠ b`.
-- Theorem `expectedDepth_le_harmonic`: `E[depth b] ≤ 2 · H_n` (once harmonic
-  numbers are imported or stated).
+- Theorem {lit}`ancestor_prob`: {lit}`P[a ancestor of b] = 1 / (|a - b| + 1)`
+  for {lit}`a ≠ b`.
+- Theorem {lit}`expectedDepth_le_harmonic`: {lit}`E[depth b] ≤ 2 · H_n` (once
+  harmonic numbers are imported or stated).
 
 Status: prototype.  The model and the reduction of the expectation to the
 ancestor probabilities are below; the ancestor-probability counting and the
-harmonic bound are the current targets.  Not registered in `literate.toml`.
+harmonic bound are the current targets.  Not registered in
+{lit}`literate.toml`.
 -/
 
 namespace CLRS.Extensions
@@ -47,19 +50,20 @@ namespace Treap
 
 open scoped BigOperators
 
-/-- Keys are `Fin n`; `n` is the number of keys. -/
+/-- Keys are {lit}`Fin n`; {lit}`n` is the number of keys. -/
 abbrev Key (n : ℕ) := Fin n
 
 /-- A random priority assignment: a permutation of the keys' priorities.
-Key `i` gets priority `σ i`. -/
+Key {lit}`i` gets priority {lit}`σ i`. -/
 abbrev PrioPerm (n : ℕ) := Equiv.Perm (Fin n)
 
-/-- The priority of key `i` under the permutation `σ`, as a natural. -/
+/-- The priority of key {lit}`i` under the permutation {lit}`σ`, as a natural. -/
 def prioOfPerm {n : ℕ} (σ : PrioPerm n) (i : Fin n) : ℕ := (σ i).1
 
-/-- Key `a` is an *ancestor* of key `b` in the canonical treap under priority
-order `σ`: every key, and for `a ≠ b`, `a` carries the maximum priority among
-the keys in the closed interval between `a` and `b`. -/
+/-- Key {lit}`a` is an *ancestor* of key {lit}`b` in the canonical treap under
+priority order {lit}`σ`: every key, and for {lit}`a ≠ b`, {lit}`a` carries the
+maximum priority among the keys in the closed interval between {lit}`a` and
+{lit}`b`. -/
 def Ancestor {n : ℕ} (σ : PrioPerm n) (a b : Fin n) : Prop :=
   a = b ∨ ∀ k ∈ Finset.Icc (min a b) (max a b), prioOfPerm σ k ≤ prioOfPerm σ a
 
@@ -68,18 +72,20 @@ instance instDecidableAncestor {n : ℕ} (σ : PrioPerm n) (a b : Fin n) :
   unfold Ancestor
   infer_instance
 
-/-- The depth of key `b` in the canonical treap under `σ`: the number of keys
-that are ancestors of `b`. -/
+/-- The depth of key {lit}`b` in the canonical treap under {lit}`σ`: the number
+of keys that are ancestors of {lit}`b`. -/
 noncomputable def depth {n : ℕ} (σ : PrioPerm n) (b : Fin n) : ℕ := by
   classical
   exact (Finset.univ.filter (fun a : Fin n => Ancestor σ a b)).card
 
-/-- The expected depth of key `b` under a uniform random priority permutation. -/
+/-- The expected depth of key {lit}`b` under a uniform random priority
+permutation. -/
 noncomputable def expectedDepth {n : ℕ} (b : Fin n) : ℝ :=
   fintypeExpect (fun σ : PrioPerm n => (depth σ b : ℝ))
 
 /-- Depth counts ancestors, so by linearity of expectation the expected depth
-is the sum over keys of the probability that the key is an ancestor of `b`. -/
+is the sum over keys of the probability that the key is an ancestor of
+{lit}`b`. -/
 theorem expectedDepth_eq_sum {n : ℕ} (b : Fin n) :
     expectedDepth b =
       ∑ a : Fin n, fintypeExpect (fun σ : PrioPerm n => indicator (Ancestor σ a b)) := by

--- a/CLRSLean/Extensions/TreapRandom.lean
+++ b/CLRSLean/Extensions/TreapRandom.lean
@@ -1,8 +1,10 @@
+import CLRSLean.Chapter_07.Section_07_3_Randomized_Quicksort.Comparison_Probability
 import CLRSLean.Extensions.RandomizedTreap
 import CLRSLean.Probability.FiniteExpectation
 import Mathlib.Tactic
 
 open CLRS.Probability
+open CLRS.Chapter07
 
 /-!
 # Randomized treap: expected depth (prototype)
@@ -31,17 +33,19 @@ because among the {lit}`k = |a - b| + 1` keys of the interval, each is equally
 likely to carry the maximum priority.  The right-hand side is a pair of
 harmonic sums, so {lit}`E[depth b] ≤ 2 · H_n = O(log n)`.
 
-Main results (targets):
+Main results:
 
-- Theorem {lit}`ancestor_prob`: {lit}`P[a ancestor of b] = 1 / (|a - b| + 1)`
-  for {lit}`a ≠ b`.
-- Theorem {lit}`expectedDepth_le_harmonic`: {lit}`E[depth b] ≤ 2 · H_n` (once
-  harmonic numbers are imported or stated).
+- Theorem {lit}`ancestor_prob`: for {lit}`a ≠ b`, {lit}`P[a ancestor of b] =
+  1 / (|a - b| + 1)`.  The proof reuses Chapter 7's minimum-position symmetry
+  lemma {lit}`isFirst_prob`, reducing the maximum-priority event to it via the
+  order-reversing involution {lit}`Fin.revPerm`.
+- Theorem {lit}`expectedDepth_le_harmonic`: {lit}`E[depth b] ≤ 2 · H_n`, so a
+  random treap has logarithmic expected depth.
 
-Status: prototype.  The model and the reduction of the expectation to the
-ancestor probabilities are below; the ancestor-probability counting and the
-harmonic bound are the current targets.  Not registered in
-{lit}`literate.toml`.
+Status: prototype.  The probabilistic core — the ancestor-probability counting
+and the harmonic bound — is complete.  The expected **height** (the maximum of
+the depths over all keys, not one fixed key) remains future work, as does
+registering the module in {lit}`literate.toml`.
 -/
 
 namespace CLRS.Extensions
@@ -96,6 +100,382 @@ theorem expectedDepth_eq_sum {n : ℕ} (b : Fin n) :
     simp [depth, indicator]
   rw [hred]
   rw [fintypeExpect_sum]
+
+/-! ## Ancestor probability
+
+For {lit}`a ≠ b`, key {lit}`a` is an ancestor of {lit}`b` exactly when it
+carries the maximum priority among the keys of the closed interval
+{lit}`[min a b, max a b]`.  Under the uniform random permutation each key of an
+interval {lit}`S` is equally likely to carry the maximum, so
+{lit}`P[a ancestor b] = 1 / (|a - b| + 1)`.
+
+The proof reuses Chapter 7's minimum-position symmetry lemma
+{lit}`isFirst_prob` instead of re-proving it for maxima: composing the random
+permutation with the order-reversing involution {lit}`Fin.revPerm` (after
+inversion) is a bijection on the sample space that turns the maximum-priority
+event into the minimum-position event. -/
+
+/-- Key {lit}`a` carries the maximum priority among the keys of the set
+{lit}`S`. -/
+def MaxOver {n : ℕ} (σ : PrioPerm n) (S : Finset (Fin n)) (a : Fin n) : Prop :=
+  a ∈ S ∧ ∀ k ∈ S, prioOfPerm σ k ≤ prioOfPerm σ a
+
+instance instDecidableMaxOver {n : ℕ} (σ : PrioPerm n) (S : Finset (Fin n)) (a : Fin n) :
+    Decidable (MaxOver σ S a) := by
+  unfold MaxOver
+  infer_instance
+
+/-- {name}`Fin.revPerm` is an involution: applying it twice is the identity. -/
+lemma revPerm_trans_revPerm {n : ℕ} :
+    (Fin.revPerm.trans Fin.revPerm : Fin n ≃ Fin n) = Equiv.refl (α := Fin n) := by
+  apply Equiv.ext
+  intro i
+  simp [Fin.revPerm_apply, Fin.rev_rev]
+
+/-- Composing the inverse of a random permutation with the order-reversing
+involution {lit}`Fin.revPerm` is a bijection on {lit}`PrioPerm n`.  Under this
+bijection the maximum-priority event becomes Chapter 7's minimum-position
+event, so the uniform distribution makes them equiprobable. -/
+def revBijection {n : ℕ} : PrioPerm n ≃ PrioPerm n where
+  toFun σ := Fin.revPerm.trans σ.symm
+  invFun π := π.symm.trans Fin.revPerm
+  left_inv := by
+    intro σ
+    change (Fin.revPerm.trans σ.symm).symm.trans Fin.revPerm = σ
+    calc
+      (Fin.revPerm.trans σ.symm).symm.trans Fin.revPerm
+          = (σ.symm.symm.trans Fin.revPerm.symm).trans Fin.revPerm := by rw [Equiv.symm_trans]
+      _ = (σ.trans Fin.revPerm).trans Fin.revPerm := by simp
+      _ = σ.trans (Fin.revPerm.trans Fin.revPerm) := by rw [Equiv.trans_assoc]
+      _ = σ := by
+        rw [revPerm_trans_revPerm]
+        rw [Equiv.trans_refl]
+  right_inv := by
+    intro π
+    change Fin.revPerm.trans (π.symm.trans Fin.revPerm).symm = π
+    calc
+      Fin.revPerm.trans (π.symm.trans Fin.revPerm).symm
+          = Fin.revPerm.trans (Fin.revPerm.symm.trans π.symm.symm) := by rw [Equiv.symm_trans]
+      _ = Fin.revPerm.trans (Fin.revPerm.trans π) := by simp
+      _ = (Fin.revPerm.trans Fin.revPerm).trans π := by rw [Equiv.trans_assoc]
+      _ = π := by
+        rw [revPerm_trans_revPerm]
+        rw [Equiv.refl_trans]
+
+/-- Under {name}`revBijection`, the position of key {lit}`x` is the reversed
+priority of {lit}`x`. -/
+lemma revBijection_symm_apply {n : ℕ} (σ : PrioPerm n) (x : Fin n) :
+    (revBijection σ).symm x = Fin.revPerm (σ x) := by
+  simp [revBijection]
+
+/-- The maximum-priority event over {lit}`S` is Chapter 7's minimum-position
+event under {name}`revBijection`. -/
+lemma maxOver_iff_firstIn {n : ℕ} (S : Finset (Fin n)) (a : Fin n) (σ : PrioPerm n) :
+    MaxOver σ S a ↔ IsFirstIn S a (revBijection σ) := by
+  unfold MaxOver IsFirstIn
+  simp only [pos, revBijection_symm_apply]
+  constructor
+  · rintro ⟨haS, hmax⟩
+    refine ⟨haS, ?_⟩
+    intro y hyS
+    rw [Fin.revPerm_apply, Fin.revPerm_apply]
+    rw [Fin.rev_le_rev (i := σ a) (j := σ y)]
+    simpa [prioOfPerm] using hmax y hyS
+  · rintro ⟨haS, hfirst⟩
+    refine ⟨haS, ?_⟩
+    intro k hkS
+    have hle : Fin.revPerm (σ a) ≤ Fin.revPerm (σ k) := by
+      simpa [pos, revBijection_symm_apply] using hfirst k hkS
+    rw [Fin.revPerm_apply, Fin.revPerm_apply] at hle
+    have hk : σ k ≤ σ a := (Fin.rev_le_rev (i := σ a) (j := σ k)).mp hle
+    simpa [prioOfPerm] using hk
+
+/-- Each key of a nonempty set {lit}`S` carries the maximum priority among
+{lit}`S` with probability {lit}`1 / |S|`, by symmetry under the uniform random
+permutation (via the Chapter 7 minimum-position lemma). -/
+theorem maxOver_prob {n : ℕ} (S : Finset (Fin n)) (hS : S.Nonempty) (a : Fin n)
+    (ha : a ∈ S) :
+    fintypeExpect (fun σ : PrioPerm n => indicator (MaxOver σ S a)) = 1 / (S.card : ℝ) := by
+  classical
+  have hFirst : fintypeExpect (fun σ : PrioPerm n => indicator (IsFirstIn S a σ)) =
+      1 / (S.card : ℝ) := by
+    unfold fintypeExpect indicator
+    rw [Finset.sum_boole]
+    rw [show (Fintype.card (PrioPerm n) : ℝ) = (Nat.factorial n : ℝ)
+      by simp [PrioPerm, Fintype.card_perm]]
+    exact isFirst_prob S hS a ha
+  calc
+    fintypeExpect (fun σ : PrioPerm n => indicator (MaxOver σ S a))
+        = fintypeExpect (fun σ : PrioPerm n => indicator (IsFirstIn S a (revBijection σ))) := by
+          apply congrArg fintypeExpect
+          funext σ
+          unfold indicator
+          simp [maxOver_iff_firstIn]
+    _ = fintypeExpect (fun σ : PrioPerm n => indicator (IsFirstIn S a σ)) := by
+          exact fintypeExpect_equiv (revBijection)
+            (fun σ : PrioPerm n => indicator (IsFirstIn S a σ))
+    _ = 1 / (S.card : ℝ) := hFirst
+
+/-- The number of keys in the closed interval between {lit}`a` and {lit}`b` is
+{lit}`|a - b| + 1`. -/
+lemma interval_card {n : ℕ} (a b : Fin n) :
+    (Finset.Icc (min a b) (max a b)).card = (max a b).val - (min a b).val + 1 := by
+  rw [Fin.card_Icc]
+  have hmm : (min a b).val ≤ (max a b).val := by
+    exact_mod_cast (min_le_max (a := a) (b := b))
+  omega
+
+/-- **Ancestor probability.**  For {lit}`a ≠ b`, the probability that {lit}`a`
+is an ancestor of {lit}`b` is {lit}`1 / (|a - b| + 1)`. -/
+theorem ancestor_prob {n : ℕ} {a b : Fin n} (hne : a ≠ b) :
+    fintypeExpect (fun σ : PrioPerm n => indicator (Ancestor σ a b)) =
+      1 / (((max a b).val - (min a b).val + 1 : ℕ) : ℝ) := by
+  classical
+  let I : Finset (Fin n) := Finset.Icc (min a b) (max a b)
+  have haI : a ∈ I := by
+    dsimp [I]
+    exact Finset.mem_Icc.mpr ⟨min_le_left a b, le_max_left a b⟩
+  have hIne : I.Nonempty := ⟨a, haI⟩
+  calc
+    fintypeExpect (fun σ : PrioPerm n => indicator (Ancestor σ a b))
+        = fintypeExpect (fun σ : PrioPerm n => indicator (MaxOver σ I a)) := by
+          apply congrArg fintypeExpect
+          funext σ
+          have hiff : Ancestor σ a b ↔ MaxOver σ I a := by
+            unfold Ancestor MaxOver
+            constructor
+            · intro h
+              rcases h with h | hmax
+              · exact False.elim (hne h)
+              · exact ⟨haI, hmax⟩
+            · intro ⟨_, hmax⟩
+              exact Or.inr hmax
+          unfold indicator
+          simp [hiff]
+    _ = 1 / (I.card : ℝ) := maxOver_prob I hIne a haI
+    _ = 1 / (((max a b).val - (min a b).val + 1 : ℕ) : ℝ) := by
+          congr 1
+          simpa [I] using (congrArg (fun x : ℕ => (x : ℝ)) (interval_card a b))
+
+/-! ## Expected depth bound
+
+With {lit}`P[a ancestor b] = 1 / (|a - b| + 1)`, linearity of expectation gives
+
+> {lit}`E[depth b] = 1 + Σ_{a ≠ b} 1 / (|a - b| + 1)`.
+
+The keys strictly below {lit}`b` form a partial harmonic sum at most
+{lit}`H_n - 1`, and the keys strictly above form another at most
+{lit}`H_n - 1`, so {lit}`E[depth b] ≤ 2 · H_n = O(log n)`. -/
+
+noncomputable def harmonicReal (m : ℕ) : ℝ := ∑ i ∈ Finset.range m, (((i + 1 : ℕ) : ℝ)⁻¹)
+
+lemma harmonicReal_eq_succ_shift {n : ℕ} (hn : 1 ≤ n) :
+    harmonicReal n = 1 + ∑ i ∈ Finset.range (n - 1), (((i + 2 : ℕ) : ℝ)⁻¹) := by
+  unfold harmonicReal
+  have hn' : n = (n - 1) + 1 := by omega
+  rw [hn']
+  rw [Finset.sum_range_succ']
+  norm_num
+  ring
+
+lemma harmonicReal_eq_harmonic (m : ℕ) : harmonicReal m = (harmonic m : ℝ) := by
+  unfold harmonicReal harmonic
+  simp [Rat.cast_sum, Rat.cast_inv]
+
+lemma below_sum_eq {n b : ℕ} (hb : b < n) :
+    (∑ i ∈ Finset.range n, if i < b then (((b - i + 1 : ℕ) : ℝ)⁻¹) else 0) =
+      ∑ i ∈ Finset.range b, (((i + 2 : ℕ) : ℝ)⁻¹) := by
+  calc
+    (∑ i ∈ Finset.range n, if i < b then (((b - i + 1 : ℕ) : ℝ)⁻¹) else 0)
+        = (∑ i ∈ (Finset.range n).filter (fun i => i < b), (((b - i + 1 : ℕ) : ℝ)⁻¹)) := by
+          rw [Finset.sum_filter]
+    _ = (∑ i ∈ Finset.range b, (((b - i + 1 : ℕ) : ℝ)⁻¹)) := by
+          rw [show (Finset.range n).filter (fun i => i < b) = Finset.range b by
+            ext i
+            rw [Finset.mem_filter]
+            simp only [Finset.mem_range]
+            constructor <;> omega]
+    _ = (∑ i ∈ Finset.range b, (((i + 2 : ℕ) : ℝ)⁻¹)) := by
+          rw [← Finset.sum_range_reflect]
+          apply Finset.sum_congr rfl
+          intro i hi
+          have hi' : i < b := Finset.mem_range.mp hi
+          have hval : b - (b - 1 - i) + 1 = i + 2 := by omega
+          rw [hval]
+
+lemma below_sum_le_harmonic_val {n b : ℕ} (hn : 1 ≤ n) (hb : b < n) :
+    (∑ i ∈ Finset.range n, if i < b then (((b - i + 1 : ℕ) : ℝ)⁻¹) else 0) ≤ harmonicReal n - 1 := by
+  calc
+    (∑ i ∈ Finset.range n, if i < b then (((b - i + 1 : ℕ) : ℝ)⁻¹) else 0)
+        = (∑ i ∈ Finset.range b, (((i + 2 : ℕ) : ℝ)⁻¹)) := below_sum_eq hb
+    _ ≤ (∑ i ∈ Finset.range (n - 1), (((i + 2 : ℕ) : ℝ)⁻¹)) := by
+          apply Finset.sum_le_sum_of_subset_of_nonneg
+          · intro i hi
+            have hib : i < b := Finset.mem_range.mp hi
+            exact Finset.mem_range.mpr (by omega)
+          · intro i hi hi_not
+            exact inv_nonneg.mpr (by positivity)
+    _ = harmonicReal n - 1 := by
+          rw [harmonicReal_eq_succ_shift hn]
+          ring
+
+lemma above_sum_eq {n b : ℕ} (hb : b < n) :
+    (∑ i ∈ Finset.range n, if b < i then (((i - b + 1 : ℕ) : ℝ)⁻¹) else 0) =
+      ∑ k ∈ Finset.range (n - 1 - b), (((k + 2 : ℕ) : ℝ)⁻¹) := by
+  calc
+    (∑ i ∈ Finset.range n, if b < i then (((i - b + 1 : ℕ) : ℝ)⁻¹) else 0)
+        = (∑ i ∈ (Finset.range n).filter (fun i => b < i), (((i - b + 1 : ℕ) : ℝ)⁻¹)) := by
+          rw [Finset.sum_filter]
+    _ = (∑ k ∈ Finset.range (n - 1 - b), (((k + 2 : ℕ) : ℝ)⁻¹)) := by
+          refine Finset.sum_bij (fun i _ => i - b - 1) ?_ ?_ ?_ ?_
+          · intro i hi
+            rw [Finset.mem_filter] at hi
+            rcases hi with ⟨hin, hbi⟩
+            have hin' : i < n := Finset.mem_range.mp hin
+            rw [Finset.mem_range]
+            omega
+          · intro i₁ hi₁ i₂ hi₂ h
+            rw [Finset.mem_filter] at hi₁ hi₂
+            rcases hi₁ with ⟨hin₁, hb₁⟩
+            rcases hi₂ with ⟨hin₂, hb₂⟩
+            omega
+          · intro k hk
+            rw [Finset.mem_range] at hk
+            refine ⟨k + b + 1, ?_, ?_⟩
+            · rw [Finset.mem_filter]
+              constructor
+              · rw [Finset.mem_range]
+                omega
+              · omega
+            · omega
+          · intro i hi
+            have hbi : b < i := by
+              rw [Finset.mem_filter] at hi
+              exact hi.2
+            have hval : i - b + 1 = i - b - 1 + 2 := by omega
+            rw [hval]
+
+lemma above_sum_le_harmonic_val {n b : ℕ} (hn : 1 ≤ n) (hb : b < n) :
+    (∑ i ∈ Finset.range n, if b < i then (((i - b + 1 : ℕ) : ℝ)⁻¹) else 0) ≤ harmonicReal n - 1 := by
+  calc
+    (∑ i ∈ Finset.range n, if b < i then (((i - b + 1 : ℕ) : ℝ)⁻¹) else 0)
+        = (∑ k ∈ Finset.range (n - 1 - b), (((k + 2 : ℕ) : ℝ)⁻¹)) := above_sum_eq hb
+    _ ≤ (∑ i ∈ Finset.range (n - 1), (((i + 2 : ℕ) : ℝ)⁻¹)) := by
+          apply Finset.sum_le_sum_of_subset_of_nonneg
+          · intro i hi
+            have hib : i < n - 1 - b := Finset.mem_range.mp hi
+            have hle : n - 1 - b ≤ n - 1 := Nat.sub_le (n - 1) b
+            exact Finset.mem_range.mpr (by omega)
+          · intro i hi hi_not
+            exact inv_nonneg.mpr (by positivity)
+    _ = harmonicReal n - 1 := by
+          rw [harmonicReal_eq_succ_shift hn]
+          ring
+
+lemma sum_split_three {n : ℕ} (b : Fin n) (X Y : Fin n → ℝ) :
+    (∑ a : Fin n, if a < b then X a else if b < a then Y a else 1) =
+      1 + (∑ a : Fin n, if a < b then X a else 0) +
+          (∑ a : Fin n, if b < a then Y a else 0) := by
+  calc
+    (∑ a : Fin n, if a < b then X a else if b < a then Y a else 1)
+        = (∑ a : Fin n, ((if a = b then 1 else 0) + (if a < b then X a else 0) + (if b < a then Y a else 0))) := by
+          apply Finset.sum_congr rfl
+          intro a ha
+          by_cases hab : a = b
+          · subst a; simp
+          · have hne : a ≠ b := hab
+            have hltgt : a < b ∨ b < a := lt_or_gt_of_ne hne
+            rcases hltgt with hlt | hgt
+            · have hba : ¬ b < a := not_lt.mpr (le_of_lt hlt)
+              have heq : ¬ a = b := ne_of_lt hlt
+              simp [hlt, hba, heq]
+            · have hnot : ¬ a < b := not_lt.mpr (le_of_lt hgt)
+              have heq : ¬ a = b := ne_of_gt hgt
+              simp [hgt, hnot, heq]
+    _ = (∑ a : Fin n, if a = b then 1 else 0) + (∑ a : Fin n, if a < b then X a else 0) +
+        (∑ a : Fin n, if b < a then Y a else 0) := by
+          simp [Finset.sum_add_distrib]
+    _ = 1 + (∑ a : Fin n, if a < b then X a else 0) + (∑ a : Fin n, if b < a then Y a else 0) := by
+          rw [Finset.sum_ite_eq']
+          simp
+
+lemma sum_fin_eq_range {n : ℕ} (b : Fin n) :
+    (∑ a : Fin n, if a < b then (((b.val - a.val + 1 : ℕ) : ℝ)⁻¹) else 0) =
+      (∑ i ∈ Finset.range n, if i < b.val then (((b.val - i + 1 : ℕ) : ℝ)⁻¹) else 0) := by
+  rw [← Fin.sum_univ_eq_sum_range
+    (fun i : ℕ => if i < b.val then (((b.val - i + 1 : ℕ) : ℝ)⁻¹) else 0)]
+  congr 1
+
+lemma sum_fin_eq_range_above {n : ℕ} (b : Fin n) :
+    (∑ a : Fin n, if b < a then (((a.val - b.val + 1 : ℕ) : ℝ)⁻¹) else 0) =
+      (∑ i ∈ Finset.range n, if b.val < i then (((i - b.val + 1 : ℕ) : ℝ)⁻¹) else 0) := by
+  rw [← Fin.sum_univ_eq_sum_range
+    (fun i : ℕ => if b.val < i then (((i - b.val + 1 : ℕ) : ℝ)⁻¹) else 0)]
+  congr 1
+
+lemma below_sum_le_harmonic {n : ℕ} (b : Fin n) :
+    (∑ a : Fin n, if a < b then (((b.val - a.val + 1 : ℕ) : ℝ)⁻¹) else 0) ≤ harmonicReal n - 1 := by
+  by_cases hn : n = 0
+  · subst n; nomatch b
+  · rw [sum_fin_eq_range b]
+    exact below_sum_le_harmonic_val (n := n) (b := b.val) (by omega) b.isLt
+
+lemma above_sum_le_harmonic {n : ℕ} (b : Fin n) :
+    (∑ a : Fin n, if b < a then (((a.val - b.val + 1 : ℕ) : ℝ)⁻¹) else 0) ≤ harmonicReal n - 1 := by
+  by_cases hn : n = 0
+  · subst n; nomatch b
+  · rw [sum_fin_eq_range_above b]
+    exact above_sum_le_harmonic_val (n := n) (b := b.val) (by omega) b.isLt
+
+theorem expectedDepth_le_harmonic {n : ℕ} (b : Fin n) :
+    expectedDepth b ≤ 2 * (harmonic n : ℝ) := by
+  classical
+  by_cases hn : n = 0
+  · subst n; nomatch b
+  · have hbd : expectedDepth b =
+        1 + (∑ a : Fin n, if a < b then (((b.val - a.val + 1 : ℕ) : ℝ)⁻¹) else 0) +
+            (∑ a : Fin n, if b < a then (((a.val - b.val + 1 : ℕ) : ℝ)⁻¹) else 0) := by
+      rw [expectedDepth_eq_sum]
+      have hsum : (∑ a : Fin n, fintypeExpect (fun σ : PrioPerm n => indicator (Ancestor σ a b))) =
+          (∑ a : Fin n, if a < b then (((b.val - a.val + 1 : ℕ) : ℝ)⁻¹) else
+                          if b < a then (((a.val - b.val + 1 : ℕ) : ℝ)⁻¹) else 1) := by
+        apply Finset.sum_congr rfl
+        intro a ha
+        by_cases hab : a = b
+        · subst a
+          have hcard : Fintype.card (PrioPerm n) ≠ 0 := by simp [PrioPerm]
+          simp [Ancestor, indicator, fintypeExpect_const hcard]
+        · have hne : a ≠ b := hab
+          rw [ancestor_prob hne]
+          have hltgt : a < b ∨ b < a := lt_or_gt_of_ne hne
+          rcases hltgt with hlt | hgt
+          · have hmax : max a b = b := max_eq_right (le_of_lt hlt)
+            have hmin : min a b = a := min_eq_left (le_of_lt hlt)
+            have hsize : (max a b).val - (min a b).val + 1 = b.val - a.val + 1 := by
+              rw [hmax, hmin]
+            rw [hsize]
+            simp [hlt]
+          · have hmax : max a b = a := max_eq_left (le_of_lt hgt)
+            have hmin : min a b = b := min_eq_right (le_of_lt hgt)
+            have hsize : (max a b).val - (min a b).val + 1 = a.val - b.val + 1 := by
+              rw [hmax, hmin]
+            have hnot : ¬ a < b := not_lt.mpr (le_of_lt hgt)
+            rw [hsize]
+            simp [hgt, hnot]
+      rw [hsum]
+      exact sum_split_three b (fun a => (((b.val - a.val + 1 : ℕ) : ℝ)⁻¹))
+        (fun a => (((a.val - b.val + 1 : ℕ) : ℝ)⁻¹))
+    have hL : (∑ a : Fin n, if a < b then (((b.val - a.val + 1 : ℕ) : ℝ)⁻¹) else 0) ≤
+        harmonicReal n - 1 := below_sum_le_harmonic b
+    have hR : (∑ a : Fin n, if b < a then (((a.val - b.val + 1 : ℕ) : ℝ)⁻¹) else 0) ≤
+        harmonicReal n - 1 := above_sum_le_harmonic b
+    calc
+      expectedDepth b ≤ 1 + (harmonicReal n - 1) + (harmonicReal n - 1) := by
+        rw [hbd]
+        nlinarith [hL, hR]
+      _ = 2 * harmonicReal n - 1 := by ring
+      _ ≤ 2 * harmonicReal n := by linarith
+      _ = 2 * (harmonic n : ℝ) := by rw [harmonicReal_eq_harmonic]
 
 end Treap
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,7 @@ CLRSLean/Chapter_33/Section_33_1_Line_Segment_Properties.lean
 CLRSLean/Chapter_32/Section_32_1_String_Model/Naive_Matcher.lean
 CLRSLean/Extensions.lean
 CLRSLean/Extensions/RandomizedTreap.lean
+CLRSLean/Extensions/TreapHeight.lean
 CLRSLean/Extensions/TreapRandom.lean
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,7 @@ CLRSLean/Chapter_33/Section_33_1_Line_Segment_Properties.lean
 CLRSLean/Chapter_32/Section_32_1_String_Model/Naive_Matcher.lean
 CLRSLean/Extensions.lean
 CLRSLean/Extensions/RandomizedTreap.lean
+CLRSLean/Extensions/TreapRandom.lean
 ```
 
 Reusable cross-chapter proof APIs live under `CLRSLean/ProofPatterns/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -178,6 +178,8 @@ CLRSLean/Chapter_27/Section_27_2_4_Algorithms.lean
 CLRSLean/Chapter_32/Section_32_1_String_Model.lean
 CLRSLean/Chapter_33/Section_33_1_Line_Segment_Properties.lean
 CLRSLean/Chapter_32/Section_32_1_String_Model/Naive_Matcher.lean
+CLRSLean/Extensions.lean
+CLRSLean/Extensions/RandomizedTreap.lean
 ```
 
 Reusable cross-chapter proof APIs live under `CLRSLean/ProofPatterns/`.

--- a/literate.toml
+++ b/literate.toml
@@ -40,6 +40,7 @@ description = "A Lean 4 companion for CLRS-style algorithm correctness proofs."
   "CLRSLean.Chapter_27",
   "CLRSLean.Chapter_32",
   "CLRSLean.Chapter_33",
+  "CLRSLean.Extensions",
   "CLRSLean.Progress",
   "CLRSLean.Status",
   "CLRSLean.Workflow",
@@ -823,6 +824,9 @@ title = "32.1. Naive Matcher — Implementation"
 
 [modules."CLRSLean.Chapter_33"]
 title = "Chapter 33. Computational Geometry"
+
+[modules."CLRSLean.Extensions"]
+title = "Extensions Beyond the Textbook"
 
 [modules."CLRSLean.Chapter_33.Section_33_1_Line_Segment_Properties"]
 title = "33.1. Line-Segment Properties"


### PR DESCRIPTION
Adds the **Extensions** area — results that go one notch beyond the CLRS
textbook — and its first prototype: a verified randomized treap.

## What's in this PR

**Extensions area** (`CLRSLean/Extensions.lean`, rendered in the site sidebar):
a guide page explaining that extensions are deliberately kept out of the
textbook-coverage ledger until promoted.

**Randomized treap correctness** (`CLRSLean/Extensions/RandomizedTreap.lean`,
921 lines, kernel-clean): an executable treap (`insert` with rotations) with
membership, BST, and heap invariants all verified.  No `sorry`; axioms are
`[propext, Classical.choice, Quot.sound]`.

**Randomized treap probabilistic analysis** (`CLRSLean/Extensions/TreapRandom.lean`,
482 lines, kernel-clean):
- The uniform-random-permutation model and the ancestor characterization:
  for `a ≠ b`, `a` is an ancestor of `b` iff it carries the max priority in
  the interval `[min a b, max a b]`.
- `ancestor_prob`: `P[a ancestor of b] = 1/(|a-b|+1)`, proved by **reusing
  Chapter 7's already-verified minimum-position lemma** `isFirst_prob` (via the
  order-reversing involution `Fin.revPerm`) rather than re-proving symmetry for
  maxima — an example of the modular-reuse story.
- `expectedDepth_le_harmonic`: `E[depth b] ≤ 2·H_n = O(log n)`, splitting the
  ancestor sum into the two one-sided harmonic sums.

## Status

Both headline theorems depend only on `[propext, Classical.choice, Quot.sound]`.
The Extensions modules remain unregistered prototypes; the expected **height**
(max depth over keys) is the remaining future step.

Checklist:
- [x] `uv run python scripts/check_repository.py` passes
- [x] `lake build CLRSLean` succeeds
- [x] No `sorry`/`admit` in any touched file
- [x] `literate.toml` renders the Extensions page

🤖 Generated with [Claude Code](https://claude.com/claude-code)