### PR TITLE
feat(ext.treap): expected-height bound E[height] ≤ 30·H_n = O(log n)

### DIFF
--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -663,6 +663,33 @@ lemma leftAncestors_tail {n : ℕ} {b : Fin n} (k : ℕ) :
           unfold C
           rw [Finset.sum_filter]
 
+-- The left-ancestor sum over the interval reciprocals is at most H_n.
+lemma left_sum_le_harmonicReal {n : ℕ} {b : Fin n} :
+    (∑ a : Fin n, if a < b then (1 / ((Finset.Icc a b).card : ℝ)) else 0) ≤ harmonicReal n := by
+  classical
+  have hconv : (∑ a : Fin n, if a < b then (1 / ((Finset.Icc a b).card : ℝ)) else 0) =
+      (∑ a : Fin n, if a < b then (((b.val - a.val + 1 : ℕ) : ℝ)⁻¹) else 0) := by
+    apply Finset.sum_congr rfl
+    intro a ha
+    by_cases hab : a < b
+    · have hcard : (Finset.Icc a b).card = b.val - a.val + 1 := by
+        have hab' : a.val < b.val := hab
+        rw [Fin.card_Icc]
+        omega
+      simp [hab, hcard, one_div]
+    · simp [hab]
+  rw [hconv]
+  calc
+    (∑ a : Fin n, if a < b then (((b.val - a.val + 1 : ℕ) : ℝ)⁻¹) else 0)
+        = (∑ i ∈ Finset.range n, if i < b.val then (((b.val - i + 1 : ℕ) : ℝ)⁻¹) else 0) := by
+          rw [sum_fin_eq_range b]
+    _ ≤ harmonicReal n - 1 := by
+          have hn1 : 1 ≤ n := Nat.succ_le_of_lt (lt_of_le_of_lt (Nat.zero_le b.val) b.isLt)
+          exact below_sum_le_harmonic_val (n := n) (b := b.val) hn1 b.isLt
+    _ ≤ harmonicReal n := by linarith
+
+set_option linter.unusedTactic false
+
 end Treap
 
 end CLRS.Extensions

--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -373,6 +373,187 @@ lemma leftAncestors_product {n : ℕ} {b : Fin n} (S : Finset (Fin n))
                   · simp
   exact hIH S.card S rfl hS
 
+/- `(n+1).choose n = n+1`. -/
+private lemma choose_succ (n : ℕ) : Nat.choose (n + 1) n = n + 1 := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Nat.choose_succ_succ]
+      rw [ih, Nat.choose_self]
+
+lemma eSymm_le {α : Type} [DecidableEq α] (C : Finset α) (x : α → ℝ)
+    (hx : ∀ a, 0 ≤ x a) (k : ℕ) :
+    (∑ s ∈ Finset.powersetCard k C, ∏ a ∈ s, x a) ≤
+      (∑ a ∈ C, x a)^k / (Nat.factorial k : ℝ) := by
+  classical
+  let S : Finset α → ℝ := fun D => ∑ a ∈ D, x a
+  let e : Finset α → ℕ → ℝ := fun D k => ∑ s ∈ Finset.powersetCard k D, ∏ a ∈ s, x a
+  have hmain : ∀ D : Finset α, ∀ k : ℕ, e D k ≤ (S D)^k / (Nat.factorial k : ℝ) := by
+    intro D
+    induction D using Finset.induction_on with
+    | empty =>
+        intro k
+        by_cases hk : k = 0
+        · subst k; simp [e, S]
+        · have hpc : Finset.powersetCard k (∅ : Finset α) = ∅ := by
+            ext s
+            rw [Finset.mem_powersetCard]
+            constructor
+            · intro h
+              have hs_empty : s = ∅ := Finset.subset_empty.mp h.1
+              have hcard0 : s.card = 0 := by rw [hs_empty]; simp
+              omega
+            · intro h; simp at h
+          have hS : S ∅ = 0 := by simp [S]
+          have he : e ∅ k = 0 := by
+            unfold e
+            rw [hpc]
+            simp
+          rw [he, hS]
+          have hz : (0 : ℝ)^k = 0 := zero_pow hk
+          simp [hz]
+    | @insert a D' haD ih =>
+        intro k
+        by_cases hk : k = 0
+        · subst k
+          simp [e, S]
+        · -- k ≥ 1, write k = n+1
+          have hkn : k = (k - 1) + 1 := by omega
+          -- powersetCard (n+1) (insert a D') splits
+          have hsplit : Finset.powersetCard k (Insert.insert a D') =
+              Finset.powersetCard k D' ∪ Finset.image (Insert.insert a) (Finset.powersetCard (k - 1) D') := by
+            rw [hkn]
+            exact Finset.powersetCard_succ_insert haD (k - 1)
+          have hdisj : Disjoint (Finset.powersetCard k D')
+              (Finset.image (Insert.insert a) (Finset.powersetCard (k - 1) D')) := by
+            -- one side has a, the other doesn't
+            rw [Finset.disjoint_left]
+            intro s hs hs2
+            rw [Finset.mem_image] at hs2
+            rcases hs2 with ⟨t, ht, hst⟩
+            -- s ∈ powersetCard k D' (so a ∉ s since a ∉ D'), but s = insert a t ∋ a. Contradiction.
+            have hsD : s ⊆ D' := (Finset.mem_powersetCard.mp hs).1
+            have has : a ∈ s := by rw [← hst]; exact Finset.mem_insert_self a t
+            have has' : a ∉ s := fun h => haD (hsD h)
+            exact has' has
+          -- e k (insert a D') = e k D' + x a * e (k-1) D'
+          have he : e (Insert.insert a D') k = e D' k + x a * e D' (k - 1) := by
+            unfold e
+            rw [hsplit, Finset.sum_union hdisj]
+            congr 1
+            -- the image part
+            rw [Finset.sum_image]
+            · -- ∑_{t ∈ powersetCard (k-1) D'} ∏_{a' ∈ insert a t} x a' = x a · e D' (k-1)
+              rw [show (∑ t ∈ Finset.powersetCard (k - 1) D', ∏ a' ∈ Insert.insert a t, x a') =
+                  x a * (∑ t ∈ Finset.powersetCard (k - 1) D', ∏ a' ∈ t, x a') by
+                rw [Finset.mul_sum]
+                apply Finset.sum_congr rfl
+                intro t ht
+                have hat : a ∉ t := fun h => haD ((Finset.mem_powersetCard.mp ht).1 h)
+                rw [Finset.prod_insert hat]]
+            · intro t₁ ht₁ t₂ ht₂ h
+              -- insert a t₁ = insert a t₂ → t₁ = t₂ (since a ∉ t₁, t₂)
+              have hat₁ : a ∉ t₁ := fun h' => haD ((Finset.mem_powersetCard.mp ht₁).1 h')
+              have hat₂ : a ∉ t₂ := fun h' => haD ((Finset.mem_powersetCard.mp ht₂).1 h')
+              have her : (Insert.insert a t₁).erase a = (Insert.insert a t₂).erase a := by
+                rw [h]
+              rw [Finset.erase_insert hat₁, Finset.erase_insert hat₂] at her
+              exact her
+          -- bound e D' k and e D' (k-1) by IH
+          have ihk : e D' k ≤ (S D')^k / (Nat.factorial k : ℝ) := ih k
+          have ihk1 : e D' (k - 1) ≤ (S D')^(k - 1) / (Nat.factorial (k - 1) : ℝ) := ih (k - 1)
+          -- binomial inequality: (S D' + x a)^k ≥ (S D')^k + k·x a·(S D')^(k-1)
+          have hbin : (S D')^k + (k : ℝ) * x a * (S D')^(k - 1) ≤ (S D' + x a)^k := by
+            let t : ℕ → ℝ := fun m => (Nat.choose k m : ℝ) * (S D')^m * (x a)^(k - m)
+            have htk : t k = (S D')^k := by
+              unfold t
+              rw [Nat.sub_self, pow_zero, mul_one, Nat.choose_self]
+              ring
+            have htk1 : t (k - 1) = (k : ℝ) * (S D')^(k - 1) * x a := by
+              unfold t
+              have hsub : k - (k - 1) = 1 := by omega
+              rw [hsub, pow_one]
+              have hc : (Nat.choose k (k - 1) : ℝ) = (k : ℝ) := by
+                have : Nat.choose k (k - 1) = k := by
+                  rcases k with _ | k'
+                  · exfalso; exact hk rfl
+                  · have : Nat.choose (k' + 1) (k' + 1 - 1) = k' + 1 := by
+                      rw [show k' + 1 - 1 = k' by omega]
+                      exact choose_succ k'
+                    simpa using this
+                exact_mod_cast this
+              rw [hc]
+            have hS_nonneg : 0 ≤ S D' := Finset.sum_nonneg (fun a ha => hx a)
+            have hnonneg : ∀ m, 0 ≤ t m := by
+              intro m
+              unfold t
+              exact mul_nonneg (mul_nonneg (by exact_mod_cast (Nat.zero_le (Nat.choose k m))) (pow_nonneg hS_nonneg m)) (pow_nonneg (hx a) (k - m))
+            have hle : t k + t (k - 1) ≤ ∑ m ∈ Finset.range (k + 1), t m := by
+              have hind : (∑ m ∈ Finset.range (k + 1), if m = k ∨ m = k - 1 then t m else 0) ≤
+                  ∑ m ∈ Finset.range (k + 1), t m := by
+                exact Finset.sum_le_sum (fun m hm => by
+                  by_cases h : m = k ∨ m = k - 1
+                  · simp [h]
+                  · simp [h, hnonneg m])
+              have hind' : (∑ m ∈ Finset.range (k + 1), if m = k ∨ m = k - 1 then t m else 0) = t k + t (k - 1) := by
+                rw [show (∑ m ∈ Finset.range (k + 1), if m = k ∨ m = k - 1 then t m else 0) =
+                    (∑ m ∈ Finset.range (k + 1), ((if m = k then t m else 0) + (if m = k - 1 then t m else 0))) by
+                  apply Finset.sum_congr rfl
+                  intro m hm
+                  have hne : k ≠ k - 1 := by omega
+                  by_cases h1 : m = k
+                  · subst m; simp [hne]
+                  · by_cases h2 : m = k - 1
+                    · subst m
+                      have hne' : k - 1 ≠ k := by omega
+                      simp [hne']
+                    · simp [h1, h2]]
+                rw [Finset.sum_add_distrib]
+                rw [Finset.sum_ite_eq']
+                rw [Finset.sum_ite_eq']
+                have hk1mem : k - 1 ∈ Finset.range (k + 1) := by
+                  rw [Finset.mem_range]; omega
+                have hkmem : k ∈ Finset.range (k + 1) := by simp
+                simp [hk1mem, hkmem]
+              rw [← hind']
+              exact hind
+            have hsum : (S D' + x a)^k = ∑ m ∈ Finset.range (k + 1), t m := by
+              rw [add_pow]
+              congr 1
+              funext m
+              simp [t]
+              ring
+            calc
+              (S D')^k + (k : ℝ) * x a * (S D')^(k - 1) = t k + t (k - 1) := by
+                rw [htk, htk1]; ring
+              _ ≤ ∑ m ∈ Finset.range (k + 1), t m := hle
+              _ = (S D' + x a)^k := hsum.symm
+          -- assemble
+          have hS' : S (Insert.insert a D') = S D' + x a := by
+            unfold S
+            rw [Finset.sum_insert haD]
+            ring
+          -- final
+          calc
+            e (Insert.insert a D') k = e D' k + x a * e D' (k - 1) := he
+            _ ≤ (S D')^k / (Nat.factorial k : ℝ) + x a * ((S D')^(k - 1) / (Nat.factorial (k - 1) : ℝ)) := by
+                  have hxa : 0 ≤ x a := hx a
+                  nlinarith [ihk, ihk1, hxa]
+            _ ≤ (S (Insert.insert a D'))^k / (Nat.factorial k : ℝ) := by
+                  rw [hS']
+                  -- need: S^k/k! + a·S^(k-1)/(k-1)! ≤ (S+a)^k/k!
+                  -- ⟺ S^k + k·a·S^(k-1) ≤ (S+a)^k  (multiply by k!, using k! = k·(k-1)!)
+                  have hfac : (Nat.factorial k : ℝ) = (k : ℝ) * (Nat.factorial (k - 1) : ℝ) := by
+                    have hnfac : Nat.factorial k = k * Nat.factorial (k - 1) := by
+                      rw [hkn]
+                      rw [Nat.factorial_succ]
+                      congr 1
+                    exact_mod_cast hnfac
+                  rw [hfac]
+                  field_simp
+                  nlinarith [hbin]
+  exact hmain C k
+
 end Treap
 
 end CLRS.Extensions

--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -29,8 +29,9 @@ Main result (target, not yet proved):
   constant {lit}`c`.
 
 Status: prototype, not registered in {lit}`literate.toml`.  The depth
-decomposition and left-ancestor product formula are kernel-checked; the
-exponential-tail and final expected-height bounds remain future work.
+decomposition, the left-ancestor product formula, the exponential tails on the
+left- and right-ancestor counts, and the single-key depth tail are
+kernel-checked.  The final expected-height bound (Step 3) remains future work.
 -/
 
 /-- The left-ancestors of key {lit}`b`: keys strictly below {lit}`b` that are
@@ -687,6 +688,201 @@ lemma left_sum_le_harmonicReal {n : ℕ} {b : Fin n} :
           have hn1 : 1 ≤ n := Nat.succ_le_of_lt (lt_of_le_of_lt (Nat.zero_le b.val) b.isLt)
           exact below_sum_le_harmonic_val (n := n) (b := b.val) hn1 b.isLt
     _ ≤ harmonicReal n := by linarith
+
+/-! ## Right-ancestor tail via reflection -/
+
+/-- Right-composition with the order-reversing involution {lit}`Fin.revPerm` is
+an involution (hence a bijection) on {lit}`PrioPerm n`. -/
+noncomputable def revCompEquiv {n : ℕ} : PrioPerm n ≃ PrioPerm n where
+  toFun σ := σ * Fin.revPerm
+  invFun σ := σ * Fin.revPerm
+  left_inv := by
+    intro σ
+    ext x
+    simp [Equiv.Perm.mul_apply, Fin.revPerm_apply, Fin.rev_rev]
+  right_inv := by
+    intro σ
+    ext x
+    simp [Equiv.Perm.mul_apply, Fin.revPerm_apply, Fin.rev_rev]
+
+/-- The ancestor relation commutes with order reversal: for {lit}`b < a`, the
+key {lit}`a` is an ancestor of {lit}`b` under {lit}`σ` iff the reversed key is
+an ancestor of the reversed key under {lit}`σ * Fin.revPerm`. -/
+lemma ancestor_rev_perm {n : ℕ} {σ : PrioPerm n} {a b : Fin n} (hab : b < a) :
+    Ancestor (σ * Fin.revPerm) (Fin.revPerm a) (Fin.revPerm b) ↔ Ancestor σ a b := by
+  classical
+  have hane : a ≠ b := ne_of_gt hab
+  have hne' : Fin.revPerm a ≠ Fin.revPerm b := by
+    intro h
+    exact hane (Fin.revPerm.injective h)
+  have hra : Fin.revPerm a < Fin.revPerm b := by
+    simpa [Fin.revPerm_apply] using (Fin.rev_lt_rev (i := a) (j := b)).2 hab
+  have hmin1 : min (Fin.revPerm a) (Fin.revPerm b) = Fin.revPerm a := min_eq_left (le_of_lt hra)
+  have hmax1 : max (Fin.revPerm a) (Fin.revPerm b) = Fin.revPerm b := max_eq_right (le_of_lt hra)
+  have hmin2 : min a b = b := min_eq_right (le_of_lt hab)
+  have hmax2 : max a b = a := max_eq_left (le_of_lt hab)
+  unfold Ancestor
+  rw [hmin1, hmax1, hmin2, hmax2]
+  simp only [hne', hane, or_false, false_or]
+  constructor
+  · intro h k hk
+    have hk' : Fin.revPerm k ∈ Finset.Icc (Fin.revPerm a) (Fin.revPerm b) := by
+      rw [Finset.mem_Icc] at hk ⊢
+      rcases hk with ⟨hbk, hka⟩
+      constructor
+      · exact (Fin.rev_le_rev (i := a) (j := k)).2 hka
+      · exact (Fin.rev_le_rev (i := k) (j := b)).2 hbk
+    have hp := h (Fin.revPerm k) hk'
+    simpa [prioOfPerm, Equiv.Perm.mul_apply, Fin.revPerm_apply, Fin.rev_rev] using hp
+  · intro h k hk
+    have hk' : Fin.revPerm k ∈ Finset.Icc b a := by
+      rw [Finset.mem_Icc] at hk ⊢
+      rcases hk with ⟨hrak, hkrb⟩
+      constructor
+      · simpa [Fin.revPerm_apply] using (Fin.le_rev_iff (i := k) (j := b)).1 hkrb
+      · simpa [Fin.revPerm_apply] using (Fin.rev_le_iff (i := a) (j := k)).1 hrak
+    have hp := h (Fin.revPerm k) hk'
+    simpa [prioOfPerm, Equiv.Perm.mul_apply, Fin.revPerm_apply, Fin.rev_rev] using hp
+
+/-- The right-ancestors of {lit}`b` are exactly the left-ancestors of the
+reversed key under the reflected permutation. -/
+lemma rightAncestors_eq_left_rev {n : ℕ} (σ : PrioPerm n) (b : Fin n) :
+    rightAncestors σ b = leftAncestors (σ * Fin.revPerm) (Fin.revPerm b) := by
+  classical
+  unfold rightAncestors leftAncestors
+  apply Finset.card_nbij (fun a => Fin.revPerm a)
+  · intro a ha
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at ha ⊢
+    rcases ha with ⟨hba, hanc⟩
+    constructor
+    · simpa [Fin.revPerm_apply] using (Fin.rev_lt_rev (i := a) (j := b)).2 hba
+    · exact (ancestor_rev_perm hba).2 hanc
+  · intro a₁ ha₁ a₂ ha₂ h
+    exact Fin.revPerm.injective h
+  · intro b' hb'
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hb'
+    rcases hb' with ⟨hb'l, hanc'⟩
+    refine ⟨Fin.revPerm b', ?_, ?_⟩
+    · simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and]
+      constructor
+      · simpa [Fin.revPerm_apply] using (Fin.lt_rev_iff (i := b) (j := b')).2 hb'l
+      · refine (ancestor_rev_perm (a := Fin.revPerm b') (b := b) ?_).1 ?_
+        · simpa [Fin.revPerm_apply] using (Fin.lt_rev_iff (i := b) (j := b')).2 hb'l
+        · simpa [Fin.revPerm_apply, Fin.rev_rev] using hanc'
+    · simp [Fin.revPerm_apply, Fin.rev_rev]
+
+/-- If {lit}`S ≤ H_n` and {lit}`S ≥ 0`, then {lit}`S^k/k! ≤ H_n^k/k!`. -/
+private lemma harmonic_pow_div_le {n : ℕ} (k : ℕ) (S : ℝ)
+    (hS : S ≤ harmonicReal n) (hS0 : 0 ≤ S) :
+    S^k / (Nat.factorial k : ℝ) ≤ (harmonicReal n)^k / (Nat.factorial k : ℝ) := by
+  have hH0 : 0 ≤ harmonicReal n := by
+    unfold harmonicReal
+    exact Finset.sum_nonneg (fun i hi => inv_nonneg.mpr (by positivity))
+  have hpow : S^k ≤ (harmonicReal n)^k := pow_le_pow_left₀ hS0 hS k
+  exact div_le_div_of_nonneg_right hpow (by positivity)
+
+/-- The probability that key {lit}`b` has at least {lit}`k` left-ancestors is
+at most {lit}`H_n^k / k!`. -/
+lemma leftAncestors_tail_le_harmonic {n : ℕ} {b : Fin n} (k : ℕ) :
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ leftAncestors σ b)) ≤
+      (harmonicReal n)^k / (Nat.factorial k : ℝ) := by
+  classical
+  calc
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ leftAncestors σ b)) ≤
+      (∑ a : Fin n, if a < b then (1 / ((Finset.Icc a b).card : ℝ)) else 0)^k /
+        (Nat.factorial k : ℝ) := by
+          exact leftAncestors_tail (b := b) k
+    _ ≤ (harmonicReal n)^k / (Nat.factorial k : ℝ) := by
+          exact harmonic_pow_div_le k _ (left_sum_le_harmonicReal (n := n) (b := b)) (by
+            exact Finset.sum_nonneg (fun a ha => by
+              by_cases h : a < b
+              · rw [if_pos h]; positivity
+              · rw [if_neg h]))
+
+/-- The probability that key {lit}`b` has at least {lit}`k` right-ancestors is
+at most {lit}`H_n^k / k!`. -/
+lemma rightAncestors_tail_le_harmonic {n : ℕ} {b : Fin n} (k : ℕ) :
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ rightAncestors σ b)) ≤
+      (harmonicReal n)^k / (Nat.factorial k : ℝ) := by
+  classical
+  calc
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ rightAncestors σ b))
+        = fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ leftAncestors (σ * Fin.revPerm) (Fin.revPerm b))) := by
+          congr 1
+          funext σ
+          simpa [rightAncestors_eq_left_rev σ b]
+    _ = fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ leftAncestors σ (Fin.revPerm b))) := by
+          exact fintypeExpect_equiv (revCompEquiv)
+            (fun σ : PrioPerm n => indicator (k ≤ leftAncestors σ (Fin.revPerm b)))
+    _ ≤ (∑ a : Fin n, if a < Fin.revPerm b then (1 / ((Finset.Icc a (Fin.revPerm b)).card : ℝ)) else 0)^k /
+          (Nat.factorial k : ℝ) := by
+          exact leftAncestors_tail (b := Fin.revPerm b) k
+    _ ≤ (harmonicReal n)^k / (Nat.factorial k : ℝ) := by
+          exact harmonic_pow_div_le k _ (left_sum_le_harmonicReal (n := n) (b := Fin.revPerm b)) (by
+            exact Finset.sum_nonneg (fun a ha => by
+              by_cases h : a < Fin.revPerm b
+              · rw [if_pos h]; positivity
+              · rw [if_neg h]))
+
+/-! ## Depth tail -/
+
+/-- The probability that the depth of key {lit}`b` is at least {lit}`k` is at
+most {lit}`2 · H_n^t / t!` where {lit}`t = (k - 1) / 2`.  Depth splits into
+left-ancestors plus right-ancestors plus itself, so {lit}`depth ≥ k` forces at
+least one side to carry at least {lit}`t` ancestors; each side has an
+exponential tail. -/
+lemma depth_tail {n : ℕ} (b : Fin n) (k : ℕ) :
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ depth σ b)) ≤
+      2 * (harmonicReal n)^((k - 1) / 2) / (Nat.factorial ((k - 1) / 2) : ℝ) := by
+  classical
+  let t : ℕ := (k - 1) / 2
+  have hcov : ∀ σ, indicator (k ≤ depth σ b) ≤
+      indicator (t ≤ leftAncestors σ b) + indicator (t ≤ rightAncestors σ b) := by
+    intro σ
+    by_cases hk : k ≤ depth σ b
+    · have hsome : t ≤ leftAncestors σ b ∨ t ≤ rightAncestors σ b := by
+        by_contra hnone
+        have hLt : leftAncestors σ b < t := Nat.lt_of_not_ge (fun h => hnone (Or.inl h))
+        have hRt : rightAncestors σ b < t := Nat.lt_of_not_ge (fun h => hnone (Or.inr h))
+        have h2t : 2 * t ≤ k := by dsimp [t]; omega
+        have hbad : depth σ b < k := by
+          rw [depth_eq_left_add_right σ b]
+          omega
+        exact (not_le_of_gt hbad) hk
+      rw [indicator, if_pos hk]
+      rcases hsome with hL | hR
+      · have h1 : indicator (t ≤ leftAncestors σ b) = 1 := by rw [indicator, if_pos hL]
+        rw [h1]
+        have hR0 : 0 ≤ indicator (t ≤ rightAncestors σ b) := by
+          unfold indicator
+          by_cases h : t ≤ rightAncestors σ b <;> simp [h]
+        linarith
+      · have h1 : indicator (t ≤ rightAncestors σ b) = 1 := by rw [indicator, if_pos hR]
+        rw [h1]
+        have hL0 : 0 ≤ indicator (t ≤ leftAncestors σ b) := by
+          unfold indicator
+          by_cases h : t ≤ leftAncestors σ b <;> simp [h]
+        linarith
+    · rw [indicator, if_neg hk]
+      have hR0 : 0 ≤ indicator (t ≤ rightAncestors σ b) := by
+        unfold indicator
+        by_cases h : t ≤ rightAncestors σ b <;> simp [h]
+      have hL0 : 0 ≤ indicator (t ≤ leftAncestors σ b) := by
+        unfold indicator
+        by_cases h : t ≤ leftAncestors σ b <;> simp [h]
+      linarith
+  calc
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ depth σ b))
+        ≤ fintypeExpect (fun σ : PrioPerm n => indicator (t ≤ leftAncestors σ b) + indicator (t ≤ rightAncestors σ b)) := by
+          exact fintypeExpect_le _ _ hcov
+    _ = fintypeExpect (fun σ : PrioPerm n => indicator (t ≤ leftAncestors σ b)) +
+        fintypeExpect (fun σ : PrioPerm n => indicator (t ≤ rightAncestors σ b)) := by
+          rw [fintypeExpect_add]
+    _ ≤ (harmonicReal n)^t / (Nat.factorial t : ℝ) + (harmonicReal n)^t / (Nat.factorial t : ℝ) := by
+          have hL := leftAncestors_tail_le_harmonic (b := b) t
+          have hR := rightAncestors_tail_le_harmonic (b := b) t
+          nlinarith
+    _ = 2 * (harmonicReal n)^t / (Nat.factorial t : ℝ) := by ring
 
 set_option linter.unusedTactic false
 

--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -284,6 +284,8 @@ lemma maxExtend_uniform {n : ℕ} {b : Fin n} (T : Finset (Fin n)) {c : Fin n}
     _ = (Finset.univ.filter (fun σ : PrioPerm n =>
           ∀ a ∈ T, MaxOver σ (Finset.Icc a b) a)).card := by rw [hcover]
 
+/-- The probability that every key of `S` is a left-ancestor of `b` is the
+product of the interval-reciprocals `∏ a ∈ S, 1/|[a,b]|`. -/
 lemma leftAncestors_product {n : ℕ} {b : Fin n} (S : Finset (Fin n))
     (hS : ∀ a ∈ S, a < b) :
     ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)).card : ℝ) =
@@ -386,6 +388,8 @@ private lemma choose_succ (n : ℕ) : Nat.choose (n + 1) n = n + 1 := by
       rw [Nat.choose_succ_succ]
       rw [ih, Nat.choose_self]
 
+/-- The elementary-symmetric sum over `k`-subsets of `C` is at most
+`(Σ a ∈ C, x a)^k / k!` (Maclaurin's inequality, elementary form). -/
 lemma eSymm_le {α : Type} [DecidableEq α] (C : Finset α) (x : α → ℝ)
     (hx : ∀ a, 0 ≤ x a) (k : ℕ) :
     (∑ s ∈ Finset.powersetCard k C, ∏ a ∈ s, x a) ≤
@@ -559,11 +563,15 @@ lemma eSymm_le {α : Type} [DecidableEq α] (C : Finset α) (x : α → ℝ)
                   nlinarith [hbin]
   exact hmain C k
 
+/-- `fintypeExpect` is monotone: a pointwise inequality yields an inequality of
+expectations. -/
 lemma fintypeExpect_le {Ω : Type} [Fintype Ω] [DecidableEq Ω] (X Y : Ω → ℝ)
     (h : ∀ ω, X ω ≤ Y ω) : fintypeExpect X ≤ fintypeExpect Y := by
   unfold fintypeExpect
   exact div_le_div_of_nonneg_right (Finset.sum_le_sum (fun ω _ => h ω)) (by positivity)
 
+/-- The probability that key `b` has at least `k` left-ancestors is at most
+`(Σ a, if a < b then 1/|[a,b]| else 0)^k / k!`. -/
 lemma leftAncestors_tail {n : ℕ} {b : Fin n} (k : ℕ) :
     fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ leftAncestors σ b)) ≤
       (∑ a : Fin n, if a < b then (1 / ((Finset.Icc a b).card : ℝ)) else 0)^k /
@@ -668,7 +676,7 @@ lemma leftAncestors_tail {n : ℕ} {b : Fin n} (k : ℕ) :
           unfold C
           rw [Finset.sum_filter]
 
--- The left-ancestor sum over the interval reciprocals is at most H_n.
+/-- The left-ancestor sum over the interval reciprocals is at most `H_n`. -/
 lemma left_sum_le_harmonicReal {n : ℕ} {b : Fin n} :
     (∑ a : Fin n, if a < b then (1 / ((Finset.Icc a b).card : ℝ)) else 0) ≤ harmonicReal n := by
   classical
@@ -1225,6 +1233,9 @@ private lemma pow_div_factorial_le_inv_two {H : ℝ} (t : ℕ) (ht1 : 1 ≤ t) (
   have hpow : (3 * H / t)^t ≤ ((1 : ℝ) / 2)^t := pow_le_pow_left₀ hdiv0 hdiv t
   exact le_trans h1 hpow
 
+/-- **Expected-height bound.**  For the uniform random treap on `n` keys,
+`E[height] ≤ 30 · H_n = O(log n)` (CLRS Theorem 13.1-style analysis; here the
+exponential-tail argument for the randomized treap). -/
 theorem expectedTreapHeight_le {n : ℕ} :
     expectedTreapHeight (n := n) ≤ 30 * (harmonic n : ℝ) := by
   classical
@@ -1415,7 +1426,6 @@ theorem expectedTreapHeight_le {n : ℕ} :
             have hK2 : 12 * H + 14 ≤ 30 * H := by nlinarith [hH1]
             nlinarith [hK1, hK2, hHreal]
 
-set_option linter.unusedTactic false
 
 end Treap
 

--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -554,6 +554,115 @@ lemma eSymm_le {α : Type} [DecidableEq α] (C : Finset α) (x : α → ℝ)
                   nlinarith [hbin]
   exact hmain C k
 
+lemma fintypeExpect_le {Ω : Type} [Fintype Ω] [DecidableEq Ω] (X Y : Ω → ℝ)
+    (h : ∀ ω, X ω ≤ Y ω) : fintypeExpect X ≤ fintypeExpect Y := by
+  unfold fintypeExpect
+  exact div_le_div_of_nonneg_right (Finset.sum_le_sum (fun ω _ => h ω)) (by positivity)
+
+lemma leftAncestors_tail {n : ℕ} {b : Fin n} (k : ℕ) :
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ leftAncestors σ b)) ≤
+      (∑ a : Fin n, if a < b then (1 / ((Finset.Icc a b).card : ℝ)) else 0)^k /
+        (Nat.factorial k : ℝ) := by
+  classical
+  let C : Finset (Fin n) := Finset.univ.filter (fun a : Fin n => a < b)
+  have hcov : ∀ σ, indicator (k ≤ leftAncestors σ b) ≤
+      ∑ S ∈ Finset.powersetCard k C, indicator (∀ a ∈ S, MaxOver σ (Finset.Icc a b) a) := by
+    intro σ
+    by_cases hk : k ≤ leftAncestors σ b
+    · have hA : ∃ S ∈ Finset.powersetCard k C, ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a := by
+        let A : Finset (Fin n) := C.filter (fun a => MaxOver σ (Finset.Icc a b) a)
+        have hAcard : k ≤ A.card := by
+          have hAeq : A.card = leftAncestors σ b := by
+            unfold A leftAncestors C
+            congr 1
+            ext a
+            simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+            constructor
+            · intro h
+              rcases h with ⟨h1, h2⟩
+              have hmm : Finset.Icc (min a b) (max a b) = Finset.Icc a b := by
+                rw [min_eq_left (le_of_lt h1), max_eq_right (le_of_lt h1)]
+              exact ⟨h1, (by
+                unfold Ancestor
+                right
+                rw [hmm]
+                exact h2.2)⟩
+            · intro h
+              rcases h with ⟨h1, h2⟩
+              have hmm : Finset.Icc (min a b) (max a b) = Finset.Icc a b := by
+                rw [min_eq_left (le_of_lt h1), max_eq_right (le_of_lt h1)]
+              exact ⟨h1, (by
+                unfold MaxOver
+                unfold Ancestor at h2
+                rcases h2 with h | hle
+                · exfalso; exact (ne_of_lt h1) h
+                · exact ⟨Finset.mem_Icc.mpr ⟨le_rfl, le_of_lt h1⟩, (by rwa [hmm] at hle)⟩)⟩
+          omega
+        rcases Finset.exists_subset_card_eq hAcard with ⟨S, hSA, hScard⟩
+        refine ⟨S, ?_, ?_⟩
+        · exact Finset.mem_powersetCard.mpr ⟨(fun a ha => (Finset.mem_filter.mp (hSA ha)).1), hScard⟩
+        · intro a ha
+          exact (Finset.mem_filter.mp (hSA ha)).2
+      have hrhs : 1 ≤ ∑ S ∈ Finset.powersetCard k C, indicator (∀ a ∈ S, MaxOver σ (Finset.Icc a b) a) := by
+        rcases hA with ⟨S, hS, hSanc⟩
+        have hS1 : indicator (∀ a ∈ S, MaxOver σ (Finset.Icc a b) a) = 1 := by
+          simp [indicator]
+          exact hSanc
+        have hle1 : indicator (∀ a ∈ S, MaxOver σ (Finset.Icc a b) a) ≤
+            ∑ T ∈ Finset.powersetCard k C, indicator (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) := by
+          have hnonneg : ∀ T ∈ Finset.powersetCard k C, 0 ≤ indicator (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) := by
+            intro T hT
+            by_cases hc : (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a)
+            · have h1 : indicator (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) = 1 := by
+                rw [indicator, if_pos hc]
+              rw [h1]; norm_num
+            · have h0 : indicator (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a) = 0 := by
+                rw [indicator, if_neg hc]
+              rw [h0]
+          exact Finset.single_le_sum (s := Finset.powersetCard k C)
+            (f := fun T => indicator (∀ a ∈ T, MaxOver σ (Finset.Icc a b) a))
+            hnonneg (by exact hS)
+        rw [hS1] at hle1
+        exact hle1
+      simpa [hk, hrhs]
+    · have hzero : indicator (k ≤ leftAncestors σ b) = 0 := by
+        rw [indicator, if_neg hk]
+      rw [hzero]
+      exact Finset.sum_nonneg (fun S hS => by
+        by_cases hc : (∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)
+        · rw [indicator, if_pos hc]; norm_num
+        · rw [indicator, if_neg hc])
+  calc
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ leftAncestors σ b))
+        ≤ fintypeExpect (fun σ : PrioPerm n => ∑ S ∈ Finset.powersetCard k C, indicator (∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)) := by
+          exact fintypeExpect_le _ _ hcov
+    _ = ∑ S ∈ Finset.powersetCard k C, fintypeExpect (fun σ : PrioPerm n => indicator (∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)) := by
+          rw [fintypeExpect_sum]
+    _ = ∑ S ∈ Finset.powersetCard k C, ∏ a ∈ S, (1 / ((Finset.Icc a b).card : ℝ)) := by
+          apply Finset.sum_congr rfl
+          intro S hS
+          have hS' : ∀ a ∈ S, a < b := by
+            intro a ha
+            have hSC : S ⊆ C := (Finset.mem_powersetCard.mp hS).1
+            exact (Finset.mem_filter.mp (hSC ha)).2
+          have hprod := leftAncestors_product S hS'
+          unfold fintypeExpect indicator
+          rw [Finset.sum_boole]
+          rw [show (Fintype.card (PrioPerm n) : ℝ) = (Nat.factorial n : ℝ) by simp [PrioPerm, Fintype.card_perm]]
+          have hnfac : (Nat.factorial n : ℝ) ≠ 0 := by positivity
+          have hprod' : ((Finset.univ.filter (fun σ : PrioPerm n => ∀ a ∈ S, MaxOver σ (Finset.Icc a b) a)).card : ℝ) =
+              (Nat.factorial n : ℝ) * ∏ a ∈ S, (1 / ((Finset.Icc a b).card : ℝ)) := by
+            rw [show (Fintype.card (PrioPerm n) : ℝ) = (Nat.factorial n : ℝ) by simp [PrioPerm, Fintype.card_perm]] at hprod
+            exact hprod
+          field_simp [hnfac]
+          exact hprod'
+    _ ≤ (∑ a ∈ C, (1 / ((Finset.Icc a b).card : ℝ)))^k / (Nat.factorial k : ℝ) := by
+          exact eSymm_le C (fun a => 1 / ((Finset.Icc a b).card : ℝ)) (by intro a; positivity) k
+    _ = (∑ a : Fin n, if a < b then (1 / ((Finset.Icc a b).card : ℝ)) else 0)^k / (Nat.factorial k : ℝ) := by
+          congr 1
+          unfold C
+          rw [Finset.sum_filter]
+
 end Treap
 
 end CLRS.Extensions

--- a/CLRSLean/Extensions/TreapHeight.lean
+++ b/CLRSLean/Extensions/TreapHeight.lean
@@ -23,15 +23,19 @@ exactly the left-to-right record maxima of the priority sequence
 has an exponential tail, so the depth does too, and a union bound over the keys
 turns it into an {lit}`O(log n)` expected-height bound.
 
-Main result (target, not yet proved):
+Main results:
 
-- Theorem {lit}`height_le_harmonic`: {lit}`E[height] ≤ c · H_n` for an explicit
-  constant {lit}`c`.
+- Theorem {lit}`expectedTreapHeight_le`: {lit}`E[height] ≤ 30 · H_n`, an
+  explicit expected-height bound.  The proof combines an exponential tail on
+  the single-key depth (via the left/right-ancestor record-maxima structure)
+  with a union bound over the keys and a tail sum split at
+  {lit}`k ≈ 12 · ⌈H_n⌉`.
 
 Status: prototype, not registered in {lit}`literate.toml`.  The depth
 decomposition, the left-ancestor product formula, the exponential tails on the
-left- and right-ancestor counts, and the single-key depth tail are
-kernel-checked.  The final expected-height bound (Step 3) remains future work.
+left- and right-ancestor counts, the single-key depth tail, and the final
+expected-height bound are all kernel-checked
+({lit}`[propext, Classical.choice, Quot.sound]`).
 -/
 
 /-- The left-ancestors of key {lit}`b`: keys strictly below {lit}`b` that are
@@ -883,6 +887,533 @@ lemma depth_tail {n : ℕ} (b : Fin n) (k : ℕ) :
           have hR := rightAncestors_tail_le_harmonic (b := b) t
           nlinarith
     _ = 2 * (harmonicReal n)^t / (Nat.factorial t : ℝ) := by ring
+
+
+/-- `k! ≥ 2^(k-1)` for `k ≥ 1`, as reals. -/
+private lemma factorial_ge_two_pow (k : ℕ) (hk : 1 ≤ k) :
+    (2 : ℝ)^(k - 1) ≤ (k.factorial : ℝ) := by
+  induction k with
+  | zero => omega
+  | succ k ih =>
+      by_cases hk0 : k = 0
+      · subst k; norm_num
+      · have hk1 : 1 ≤ k := by omega
+        have ih' : (2 : ℝ)^(k - 1) ≤ (k.factorial : ℝ) := ih hk1
+        calc
+          (2 : ℝ)^((k + 1) - 1) = (2 : ℝ)^k := by rw [show (k + 1) - 1 = k by omega]
+          _ = (2 : ℝ) * (2 : ℝ)^(k - 1) := by
+                have hpow : (2 : ℝ)^k = (2 : ℝ)^(k - 1) * 2 := by
+                  rw [show k = (k - 1) + 1 by omega]
+                  rw [pow_add]
+                  norm_num
+                rw [hpow]
+                ring
+          _ ≤ (k + 1 : ℝ) * (2 : ℝ)^(k - 1) := by
+                have hk2 : 2 ≤ (k + 1 : ℝ) := by exact_mod_cast (Nat.succ_le_succ hk1)
+                exact mul_le_mul_of_nonneg_right hk2 (by positivity)
+          _ ≤ (k + 1 : ℝ) * (k.factorial : ℝ) := by
+                exact mul_le_mul_of_nonneg_left ih' (by positivity)
+          _ = ((k + 1 : ℕ).factorial : ℝ) := by
+                rw [Nat.factorial_succ]
+                norm_num
+
+/-- The tail `Σ_{i<m} (1/2)^i ≤ 2`. -/
+private lemma geom_sum_inv_two_le (m : ℕ) :
+    (∑ i ∈ Finset.range m, ((1 : ℝ) / 2)^i) ≤ 2 := by
+  have hmul := geom_sum_mul_neg ((1 : ℝ) / 2) m
+  have hsum_le : (∑ i ∈ Finset.range m, ((1 : ℝ) / 2)^i) * (1 - (1 : ℝ) / 2) ≤ 1 := by
+    rw [hmul]
+    have hpow0 : 0 ≤ ((1 : ℝ) / 2)^m := by positivity
+    linarith
+  have hstep : (∑ i ∈ Finset.range m, ((1 : ℝ) / 2)^i) * (1 - (1 : ℝ) / 2) ≤ 2 * (1 - (1 : ℝ) / 2) := by
+    have h2 : 2 * (1 - (1 : ℝ) / 2) = 1 := by norm_num
+    rw [h2]
+    exact hsum_le
+  have hhalf : (0 : ℝ) < 1 - (1 : ℝ) / 2 := by norm_num
+  exact le_of_mul_le_mul_right hstep hhalf
+
+/-- `Σ_{k=0}^{n} 1/k! ≤ 3`. -/
+private lemma sum_inv_factorial_le_three (n : ℕ) :
+    (∑ k ∈ Finset.range (n + 1), (1 : ℝ) / (k.factorial : ℝ)) ≤ 3 := by
+  have hsplit : (∑ k ∈ Finset.range (n + 1), (1 : ℝ) / (k.factorial : ℝ)) =
+      (1 : ℝ) + ∑ k ∈ Finset.range n, (1 : ℝ) / ((k + 1).factorial : ℝ) := by
+    rw [Finset.sum_range_succ']
+    rw [add_comm]
+    norm_num
+  rw [hsplit]
+  have hb : (∑ k ∈ Finset.range n, (1 : ℝ) / ((k + 1).factorial : ℝ)) ≤
+      (∑ k ∈ Finset.range n, ((1 : ℝ) / 2)^k) := by
+    apply Finset.sum_le_sum
+    intro k hk
+    have hf := factorial_ge_two_pow (k + 1) (by omega)
+    have hf2 : (2 : ℝ)^k ≤ ((k + 1).factorial : ℝ) := by simpa [Nat.succ_eq_add_one] using hf
+    have hf' : (1 : ℝ) / ((k + 1).factorial : ℝ) ≤ ((1 : ℝ) / 2)^k := by
+      have hfac0 : (0 : ℝ) < ((k + 1).factorial : ℝ) := by positivity
+      have h2pos : (0 : ℝ) < (2 : ℝ)^k := by positivity
+      have hle := (inv_le_inv₀ hfac0 h2pos).mpr hf2
+      rw [one_div, one_div]
+      simpa [inv_pow] using hle
+    exact hf'
+  calc
+    (1 : ℝ) + ∑ k ∈ Finset.range n, (1 : ℝ) / ((k + 1).factorial : ℝ)
+        ≤ (1 : ℝ) + ∑ k ∈ Finset.range n, ((1 : ℝ) / 2)^k := by
+          nlinarith [hb]
+    _ ≤ 3 := by
+          have hgeom : (∑ k ∈ Finset.range n, ((1 : ℝ) / 2)^k) ≤ 2 := geom_sum_inv_two_le n
+          nlinarith
+
+/-- `(1 + 1/n)^n ≤ 3` for `n ≥ 1`. -/
+private lemma one_add_one_div_pow_le_three (n : ℕ) (hn : 1 ≤ n) :
+    ((1 : ℝ) + (1 : ℝ) / n)^n ≤ 3 := by
+  have hnz : (n : ℝ) ≠ 0 := by positivity
+  calc
+    ((1 : ℝ) + (1 : ℝ) / n)^n
+        = (∑ k ∈ Finset.range (n + 1), (n.choose k : ℝ) * ((1 : ℝ) / n)^k) := by
+          rw [add_comm (1 : ℝ)]
+          rw [add_pow]
+          simp [mul_assoc, mul_comm, mul_left_comm]
+    _ ≤ (∑ k ∈ Finset.range (n + 1), (1 : ℝ) / (k.factorial : ℝ)) := by
+          apply Finset.sum_le_sum
+          intro k hk
+          have hck : (n.choose k : ℝ) * (k.factorial : ℝ) ≤ (n : ℝ)^k := by
+            have hc := Nat.choose_le_pow_div (α := ℝ) k n
+            have hf : (0 : ℝ) < (k.factorial : ℝ) := by positivity
+            rwa [le_div_iff₀ hf] at hc
+          have hnpos : (0 : ℝ) < (n : ℝ)^k := pow_pos (by positivity) k
+          have hf : (0 : ℝ) < (k.factorial : ℝ) := by positivity
+          have hck' : (n.choose k : ℝ) / (n : ℝ)^k ≤ (1 : ℝ) / (k.factorial : ℝ) := by
+            exact (div_le_div_iff₀ hnpos hf).2 (by simpa using hck)
+          have hcv : (n.choose k : ℝ) * ((1 : ℝ) / n)^k = (n.choose k : ℝ) / (n : ℝ)^k := by
+            have hpow : ((1 : ℝ) / n)^k = (1 : ℝ) / (n : ℝ)^k := by
+              rw [one_div, inv_pow, one_div]
+            rw [hpow]
+            field_simp [hnz]
+          rw [hcv]
+          exact hck'
+    _ ≤ 3 := sum_inv_factorial_le_three n
+
+/-- `t^t / t! ≤ 3^t` for `t ≥ 1`. -/
+private lemma pow_div_factorial_le_three (t : ℕ) (ht : 1 ≤ t) :
+    (t : ℝ)^t / (t.factorial : ℝ) ≤ (3 : ℝ)^t := by
+  have hle : (t : ℝ)^t ≤ (t.factorial : ℝ) * (3 : ℝ)^t := by
+    induction t with
+    | zero => omega
+    | succ t ih =>
+        by_cases ht0 : t = 0
+        · subst t; norm_num
+        · have ht1 : 1 ≤ t := by omega
+          have ht0' : (0 : ℝ) < (t : ℝ) := by exact_mod_cast (lt_of_lt_of_le (by norm_num) ht1)
+          have ih' : (t : ℝ)^t ≤ (t.factorial : ℝ) * (3 : ℝ)^t := ih ht1
+          have hone : ((1 : ℝ) + (1 : ℝ) / t)^t ≤ 3 := one_add_one_div_pow_le_three t ht1
+          have hone_nonneg : 0 ≤ ((1 : ℝ) + (1 : ℝ) / t)^t := by
+            have h1t : 0 ≤ (1 : ℝ) / t := div_nonneg (by norm_num) (le_of_lt ht0')
+            exact pow_nonneg (by linarith) t
+          have htz : (t : ℝ) ≠ 0 := by positivity
+          calc
+            ((t + 1 : ℕ) : ℝ)^(t + 1) = ((t : ℝ) + 1)^(t + 1) := by norm_num
+            _ = ((t : ℝ) + 1) * ((t : ℝ) + 1)^t := by rw [pow_succ]; ring
+            _ = ((t : ℝ) + 1) * ((t : ℝ)^t * ((1 : ℝ) + (1 : ℝ) / t)^t) := by
+                  congr 1
+                  rw [← mul_pow]
+                  congr 1
+                  field_simp [htz]
+            _ ≤ ((t : ℝ) + 1) * ((t.factorial : ℝ) * (3 : ℝ)^t * 3) := by
+                  have hprod : (t : ℝ)^t * ((1 : ℝ) + (1 : ℝ) / t)^t ≤
+                      (t.factorial : ℝ) * (3 : ℝ)^t * 3 := by
+                    have h1 : (t : ℝ)^t * ((1 : ℝ) + (1 : ℝ) / t)^t ≤
+                        (t.factorial : ℝ) * (3 : ℝ)^t * ((1 : ℝ) + (1 : ℝ) / t)^t := by
+                      exact mul_le_mul_of_nonneg_right ih' hone_nonneg
+                    have h2 : (t.factorial : ℝ) * (3 : ℝ)^t * ((1 : ℝ) + (1 : ℝ) / t)^t ≤
+                        (t.factorial : ℝ) * (3 : ℝ)^t * 3 := by
+                      have hf3 : 0 ≤ (t.factorial : ℝ) * (3 : ℝ)^t := by positivity
+                      exact mul_le_mul_of_nonneg_left hone hf3
+                    exact le_trans h1 h2
+                  have hpos : 0 ≤ (t : ℝ) + 1 := by positivity
+                  exact mul_le_mul_of_nonneg_left hprod hpos
+            _ = ((t + 1 : ℕ).factorial : ℝ) * (3 : ℝ)^(t + 1) := by
+                  rw [Nat.factorial_succ]
+                  norm_num
+                  ring
+  have hfac0 : (0 : ℝ) < (t.factorial : ℝ) := by positivity
+  rw [div_le_iff₀ hfac0]
+  calc
+    (t : ℝ)^t ≤ (t.factorial : ℝ) * (3 : ℝ)^t := hle
+    _ = (3 : ℝ)^t * (t.factorial : ℝ) := by ring
+
+
+
+/-- `n ≤ exp(H_n)`, from `log(n+1) ≤ H_n`. -/
+private lemma nat_le_exp_harmonicReal {n : ℕ} : (n : ℝ) ≤ Real.exp (harmonicReal n) := by
+  have hlog : Real.log ((n + 1 : ℕ) : ℝ) ≤ harmonicReal n := by
+    have h := log_add_one_le_harmonic n
+    rw [← harmonicReal_eq_harmonic] at h
+    exact h
+  have hpos : 0 < ((n + 1 : ℕ) : ℝ) := by positivity
+  calc
+    (n : ℝ) ≤ (n + 1 : ℕ) := by exact_mod_cast (Nat.le_succ n)
+    _ = Real.exp (Real.log ((n + 1 : ℕ) : ℝ)) := by rw [Real.exp_log hpos]
+    _ ≤ Real.exp (harmonicReal n) := by exact Real.exp_le_exp.mpr hlog
+
+/-- `(n²)·(1/2)^(6·Kh) ≤ 1` when `H_n ≤ Kh`. -/
+private lemma n_sq_mul_inv_pow_le_one {n : ℕ} (Kh : ℕ) (hH : harmonicReal n ≤ (Kh : ℝ)) :
+    (n : ℝ)^2 * ((1 : ℝ) / 2)^(6 * Kh) ≤ 1 := by
+  have hn : (n : ℝ) ≤ Real.exp (harmonicReal n) := nat_le_exp_harmonicReal
+  have hpos : (0 : ℝ) ≤ Real.exp (harmonicReal n) := (Real.exp_pos (harmonicReal n)).le
+  have hsq : (n : ℝ)^2 ≤ (Real.exp (harmonicReal n))^2 := by nlinarith
+  have hsq' : (n : ℝ)^2 ≤ Real.exp (2 * harmonicReal n) := by
+    have h : (Real.exp (harmonicReal n))^2 = Real.exp (2 * harmonicReal n) := by
+      rw [pow_two]
+      rw [← Real.exp_add]
+      ring_nf
+    rw [h] at hsq
+    exact hsq
+  have hExp2 : Real.exp (2 * harmonicReal n) ≤ Real.exp (2 * (Kh : ℝ)) := by
+    exact Real.exp_le_exp.mpr (by nlinarith [hH])
+  have hExpKh : Real.exp (2 * (Kh : ℝ)) = (Real.exp 2)^Kh := by
+    rw [show (2 : ℝ) * (Kh : ℝ) = (Kh : ℝ) * 2 by ring]
+    rw [Real.exp_nat_mul]
+  have hbase : Real.exp 2 * ((1 : ℝ) / 2)^6 ≤ 1 := by
+    have h2 : Real.exp 2 < 64 := by
+      have h1 : Real.exp 1 < 3 := by exact lt_trans Real.exp_one_lt_d9 (by norm_num)
+      calc
+        Real.exp 2 = Real.exp (1 + 1) := by norm_num
+        _ = Real.exp 1 * Real.exp 1 := by rw [Real.exp_add]
+        _ < 9 := by nlinarith [h1, (Real.exp_pos 1)]
+        _ < 64 := by norm_num
+    have h6 : ((1 : ℝ) / 2)^6 = (1 : ℝ) / 64 := by norm_num
+    rw [h6]
+    have hd : Real.exp 2 * (1 / 64) = Real.exp 2 / 64 := by ring
+    rw [hd]
+    have hle : Real.exp 2 ≤ 64 := le_of_lt h2
+    have h64 : (0 : ℝ) < 64 := by norm_num
+    rw [div_le_one₀ h64]
+    exact hle
+  calc
+    (n : ℝ)^2 * ((1 : ℝ) / 2)^(6 * Kh) ≤ Real.exp (2 * harmonicReal n) * ((1 : ℝ) / 2)^(6 * Kh) := by
+      exact mul_le_mul_of_nonneg_right hsq' (by positivity)
+    _ ≤ Real.exp (2 * (Kh : ℝ)) * ((1 : ℝ) / 2)^(6 * Kh) := by
+      exact mul_le_mul_of_nonneg_right hExp2 (by positivity)
+    _ = (Real.exp 2)^Kh * ((1 : ℝ) / 2)^(6 * Kh) := by rw [hExpKh]
+    _ = (Real.exp 2 * ((1 : ℝ) / 2)^6)^Kh := by
+      rw [pow_mul]
+      rw [← mul_pow]
+    _ ≤ 1 := by
+      have hb0 : 0 ≤ Real.exp 2 * ((1 : ℝ) / 2)^6 := by positivity
+      exact pow_le_one₀ hb0 hbase
+
+/-- The depth of a key is at most `n`. -/
+lemma depth_le_n {n : ℕ} (σ : PrioPerm n) (b : Fin n) : depth σ b ≤ n := by
+  classical
+  unfold depth
+  simpa using Finset.card_le_univ (s := Finset.univ.filter (fun a : Fin n => Ancestor σ a b))
+
+/-- The height of a treap is at most `n`. -/
+lemma treapHeight_le_n {n : ℕ} (σ : PrioPerm n) : treapHeight σ ≤ n := by
+  unfold treapHeight
+  exact Finset.sup_le (fun b hb => depth_le_n σ b)
+
+/-- A natural `h ≤ n` is the number of `k ∈ [1, n]` with `k ≤ h`. -/
+private lemma nat_eq_sum_indicator {h n : ℕ} (hh : h ≤ n) :
+    (h : ℝ) = ∑ k ∈ Finset.Icc 1 n, indicator (k ≤ h) := by
+  classical
+  have hboole : (∑ k ∈ Finset.Icc 1 n, indicator (k ≤ h)) = ((Finset.Icc 1 n).filter (fun k => k ≤ h)).card := by
+    simp [indicator]
+  have hset : (Finset.Icc 1 n).filter (fun k => k ≤ h) = Finset.Icc 1 h := by
+    ext k
+    simp only [Finset.mem_filter, Finset.mem_Icc]
+    constructor
+    · intro hk
+      rcases hk with ⟨hk1, hk2⟩
+      rcases hk1 with ⟨hk1a, hk1b⟩
+      exact ⟨hk1a, hk2⟩
+    · intro hk
+      rcases hk with ⟨hk1, hk2⟩
+      constructor
+      · constructor <;> omega
+      · exact hk2
+  rw [hboole, hset, Nat.card_Icc]
+  congr 1
+
+/-- `E[height]` equals the tail-sum `Σ_{k=1}^{n} P[height ≥ k]`. -/
+lemma expectedTreapHeight_eq_sum {n : ℕ} :
+    expectedTreapHeight (n := n) =
+      ∑ k ∈ Finset.Icc 1 n, fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ treapHeight σ)) := by
+  classical
+  unfold expectedTreapHeight
+  have hred : (fun σ : PrioPerm n => (treapHeight σ : ℝ)) =
+      fun σ : PrioPerm n => ∑ k ∈ Finset.Icc 1 n, indicator (k ≤ treapHeight σ) := by
+    funext σ
+    exact nat_eq_sum_indicator (treapHeight_le_n σ)
+  rw [hred]
+  rw [fintypeExpect_sum]
+
+/-- Union bound: `P[height ≥ k] ≤ Σ_b P[depth(b) ≥ k]`. -/
+lemma height_tail {n : ℕ} (k : ℕ) (hk1 : 1 ≤ k) :
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ treapHeight σ)) ≤
+      (n : ℝ) * (2 * (harmonicReal n)^((k - 1) / 2) / (Nat.factorial ((k - 1) / 2) : ℝ)) := by
+  classical
+  have hcov : ∀ σ, indicator (k ≤ treapHeight σ) ≤
+      ∑ b : Fin n, indicator (k ≤ depth σ b) := by
+    intro σ
+    by_cases hk : k ≤ treapHeight σ
+    · rw [indicator, if_pos hk]
+      have hex : ∃ b : Fin n, k ≤ depth σ b := by
+        by_contra hnone
+        have hall : ∀ b : Fin n, depth σ b < k := by
+          intro b
+          exact Nat.lt_of_not_ge (fun h => hnone ⟨b, h⟩)
+        have hle : treapHeight σ ≤ k - 1 := by
+          unfold treapHeight
+          exact Finset.sup_le (fun b hb => Nat.le_sub_one_of_lt (hall b))
+        omega
+      rcases hex with ⟨b, hb⟩
+      have h1 : indicator (k ≤ depth σ b) = 1 := by rw [indicator, if_pos hb]
+      have hnonneg : ∀ b' ∈ (Finset.univ : Finset (Fin n)), 0 ≤ indicator (k ≤ depth σ b') := by
+        intro b' hb'
+        by_cases h : k ≤ depth σ b' <;> simp [indicator, h]
+      have hle1 : (1 : ℝ) ≤ ∑ b' : Fin n, indicator (k ≤ depth σ b') := by
+        have hle := Finset.single_le_sum hnonneg (Finset.mem_univ b)
+        rwa [h1] at hle
+      exact hle1
+    · rw [indicator, if_neg hk]
+      exact Finset.sum_nonneg (fun b hb => by by_cases h : k ≤ depth σ b <;> simp [indicator, h])
+  calc
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ treapHeight σ))
+        ≤ fintypeExpect (fun σ : PrioPerm n => ∑ b : Fin n, indicator (k ≤ depth σ b)) := by
+          exact fintypeExpect_le _ _ hcov
+    _ = ∑ b : Fin n, fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ depth σ b)) := by
+          rw [fintypeExpect_sum]
+    _ ≤ ∑ b : Fin n, (2 * (harmonicReal n)^((k - 1) / 2) / (Nat.factorial ((k - 1) / 2) : ℝ)) := by
+          apply Finset.sum_le_sum
+          intro b hb
+          exact depth_tail b k
+    _ = (n : ℝ) * (2 * (harmonicReal n)^((k - 1) / 2) / (Nat.factorial ((k - 1) / 2) : ℝ)) := by
+          rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+          simp [nsmul_eq_mul]
+
+
+
+/-- `H^t / t! ≤ (1/2)^t` when `t ≥ 6H` and `H ≥ 0`. -/
+private lemma pow_div_factorial_le_inv_two {H : ℝ} (t : ℕ) (ht1 : 1 ≤ t) (hH0 : 0 ≤ H)
+    (ht6 : (t : ℝ) ≥ 6 * H) : H^t / (t.factorial : ℝ) ≤ ((1 : ℝ) / 2)^t := by
+  have hf := pow_div_factorial_le_three t ht1
+  have htz : (t : ℝ) ≠ 0 := by positivity
+  have htpos : (0 : ℝ) < (t : ℝ) := by positivity
+  have hHt0 : 0 ≤ H / t := div_nonneg hH0 (le_of_lt htpos)
+  have hpow0 : 0 ≤ (H / t)^t := pow_nonneg hHt0 t
+  have h1 : H^t / (t.factorial : ℝ) ≤ (3 * H / t)^t := by
+    calc
+      H^t / (t.factorial : ℝ) = (H / t)^t * (t : ℝ)^t / (t.factorial : ℝ) := by
+        have h : (H / t)^t * (t : ℝ)^t = H^t := by
+          rw [← mul_pow]
+          congr 1
+          field_simp [htz]
+        rw [h]
+      _ = (H / t)^t * ((t : ℝ)^t / (t.factorial : ℝ)) := by ring
+      _ ≤ (H / t)^t * (3 : ℝ)^t := by
+        exact mul_le_mul_of_nonneg_left hf hpow0
+      _ = (3 * H / t)^t := by
+        rw [← mul_pow]
+        congr 1
+        field_simp [htz]
+  have hdiv : 3 * H / t ≤ (1 : ℝ) / 2 := by
+    rw [div_le_iff₀ htpos]
+    have h2 : (1 : ℝ) / 2 * (t : ℝ) = (t : ℝ) / 2 := by ring
+    rw [h2]
+    exact (le_div_iff₀ (by norm_num : (0 : ℝ) < 2)).mpr (by nlinarith [ht6])
+  have hdiv0 : 0 ≤ 3 * H / t := div_nonneg (mul_nonneg (by norm_num) hH0) (le_of_lt htpos)
+  have hpow : (3 * H / t)^t ≤ ((1 : ℝ) / 2)^t := pow_le_pow_left₀ hdiv0 hdiv t
+  exact le_trans h1 hpow
+
+theorem expectedTreapHeight_le {n : ℕ} :
+    expectedTreapHeight (n := n) ≤ 30 * (harmonic n : ℝ) := by
+  classical
+  by_cases hn : n = 0
+  · subst n
+    simp [expectedTreapHeight, treapHeight, depth, PrioPerm, fintypeExpect]
+  · have hn1 : 1 ≤ n := by omega
+    let H : ℝ := harmonicReal n
+    have hH0 : 0 ≤ H := by
+      unfold H harmonicReal
+      exact Finset.sum_nonneg (fun i hi => inv_nonneg.mpr (by positivity))
+    have hH1 : 1 ≤ H := by
+      unfold H harmonicReal
+      have hmem : 0 ∈ Finset.range n := by rw [Finset.mem_range]; omega
+      have hnonneg : ∀ i ∈ Finset.range n, 0 ≤ ((i + 1 : ℕ) : ℝ)⁻¹ := by
+        intro i hi
+        exact inv_nonneg.mpr (by positivity)
+      have hterm : ((0 + 1 : ℕ) : ℝ)⁻¹ = 1 := by norm_num
+      have hle := Finset.single_le_sum hnonneg hmem
+      rwa [hterm] at hle
+    let Kh : ℕ := Nat.ceil H
+    have hKh : H ≤ (Kh : ℝ) := by
+      dsimp [Kh]
+      exact (Nat.ceil_le (n := Nat.ceil H)).mp le_rfl
+    have hKh1 : 1 ≤ Kh := by exact_mod_cast (le_trans hH1 hKh)
+    have hKh_le : (Kh : ℝ) ≤ H + 1 := by
+      have hc : Nat.ceil H ≤ Nat.floor H + 1 := by
+        rw [Nat.ceil_le]
+        rw [Nat.cast_add]
+        norm_num
+        exact le_of_lt (Nat.lt_floor_add_one H)
+      have hfl : (Nat.floor H : ℝ) ≤ H := Nat.floor_le hH0
+      dsimp [Kh]
+      have hc' : (Nat.ceil H : ℝ) ≤ ((Nat.floor H : ℕ) + 1 : ℝ) := by exact_mod_cast hc
+      have hcast : ((Nat.floor H : ℕ) + 1 : ℝ) = (Nat.floor H : ℝ) + 1 := by norm_num
+      nlinarith [hc', hfl, hcast]
+    let K : ℕ := 12 * Kh
+    let T : ℕ := 6 * Kh
+    have hT : (T : ℝ) ≥ 6 * H := by
+      dsimp [T]
+      norm_num
+      nlinarith [hKh]
+    have hT1 : 1 ≤ T := by dsimp [T]; omega
+    have hdecay : (n : ℝ)^2 * ((1 : ℝ) / 2)^T ≤ 1 := by
+      have hd := n_sq_mul_inv_pow_le_one Kh hKh
+      simpa [T] using hd
+    let P : ℕ → ℝ := fun k => fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ treapHeight σ))
+    have hhead : (∑ k ∈ Finset.Icc 1 n, if k ≤ K then P k else 0) ≤ (K : ℝ) := by
+      have hP1 : ∀ k, P k ≤ 1 := by
+        intro k
+        unfold P
+        have hpt : ∀ σ : PrioPerm n, indicator (k ≤ treapHeight σ) ≤ (1 : ℝ) := by
+          intro σ
+          by_cases h : k ≤ treapHeight σ <;> simp [indicator, h]
+        calc
+          fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ treapHeight σ)) ≤ fintypeExpect (fun σ : PrioPerm n => (1 : ℝ)) := by
+            exact fintypeExpect_le _ _ hpt
+          _ = 1 := by
+            have hcard : Fintype.card (PrioPerm n) ≠ 0 := by simp [PrioPerm]
+            exact fintypeExpect_const hcard (1 : ℝ)
+      calc
+        (∑ k ∈ Finset.Icc 1 n, if k ≤ K then P k else 0)
+            ≤ (∑ k ∈ Finset.Icc 1 n, if k ≤ K then (1 : ℝ) else 0) := by
+              apply Finset.sum_le_sum
+              intro k hk
+              by_cases h : k ≤ K
+              · simp [h, hP1 k]
+              · simp [h]
+        _ = ((Finset.Icc 1 n).filter (fun k => k ≤ K)).card := by
+              simp [Finset.sum_boole]
+        _ ≤ (K : ℝ) := by
+              have hsub : (Finset.Icc 1 n).filter (fun k => k ≤ K) ⊆ Finset.Icc 1 K := by
+                intro k hk
+                rw [Finset.mem_filter] at hk
+                rw [Finset.mem_Icc] at hk ⊢
+                exact ⟨hk.1.1, hk.2⟩
+              have hcard : ((Finset.Icc 1 n).filter (fun k => k ≤ K)).card ≤ (Finset.Icc 1 K).card := Finset.card_le_card hsub
+              have hcardK : (Finset.Icc 1 K).card = K := by
+                rw [Nat.card_Icc]
+                omega
+              rw [hcardK] at hcard
+              exact_mod_cast hcard
+    have htail : (∑ k ∈ Finset.Icc 1 n, if K < k then P k else 0) ≤ (2 : ℝ) := by
+      have hPk : ∀ k, K < k → P k ≤ (n : ℝ) * (2 * ((1 : ℝ) / 2)^T) := by
+        intro k hkK
+        have hk1 : 1 ≤ k := by omega
+        have ht := height_tail (n := n) k hk1
+        let t : ℕ := (k - 1) / 2
+        have htT : T ≤ t := by
+          have hK2 : K / 2 ≤ (k - 1) / 2 := by
+            exact Nat.div_le_div_right (by omega : K ≤ k - 1)
+          have hKd : K / 2 = T := by
+            dsimp [K, T]
+            omega
+          rw [← hKd]
+          exact hK2
+        have hterm : H^t / (t.factorial : ℝ) ≤ ((1 : ℝ) / 2)^T := by
+          have h1t : 1 ≤ t := by omega
+          have hlt := pow_div_factorial_le_inv_two t h1t hH0 ?_
+          · have hle1 : H^t / (t.factorial : ℝ) ≤ ((1 : ℝ) / 2)^t := hlt
+            have hpow : ((1 : ℝ) / 2)^t ≤ ((1 : ℝ) / 2)^T := by
+              exact pow_le_pow_of_le_one (by norm_num) (by norm_num) htT
+            exact le_trans hle1 hpow
+          · have ht6 : (6 : ℝ) * H ≤ (t : ℝ) := by
+              have h1 : (T : ℝ) ≤ (t : ℝ) := by exact_mod_cast htT
+              nlinarith [hT, h1]
+            exact ht6
+        unfold P
+        have hfac : (2 * H^t / (t.factorial : ℝ)) ≤ 2 * ((1 : ℝ) / 2)^T := by
+          calc
+            (2 * H^t / (t.factorial : ℝ)) = 2 * (H^t / (t.factorial : ℝ)) := by
+              rw [mul_div_assoc]
+            _ ≤ 2 * ((1 : ℝ) / 2)^T := by
+              exact mul_le_mul_of_nonneg_left hterm (by norm_num)
+        calc
+          fintypeExpect (fun σ => indicator (k ≤ treapHeight σ)) ≤ (n : ℝ) * (2 * H^t / (t.factorial : ℝ)) := by
+            simpa [t] using ht
+          _ ≤ (n : ℝ) * (2 * ((1 : ℝ) / 2)^T) := by
+            exact mul_le_mul_of_nonneg_left hfac (by positivity)
+      calc
+        (∑ k ∈ Finset.Icc 1 n, if K < k then P k else 0)
+            ≤ (∑ k ∈ Finset.Icc 1 n, if K < k then (n : ℝ) * (2 * ((1 : ℝ) / 2)^T) else 0) := by
+              apply Finset.sum_le_sum
+              intro k hk
+              by_cases h : K < k
+              · simpa [h] using hPk k h
+              · simp [h]
+        _ ≤ (n : ℝ) * (2 * ((1 : ℝ) / 2)^T) * n := by
+              have hf : (Finset.Icc 1 n).filter (fun k => K < k) = Finset.Icc (K + 1) n := by
+                ext k
+                simp only [Finset.mem_filter, Finset.mem_Icc]
+                constructor
+                · intro hk
+                  rcases hk with ⟨hk1, hk2⟩
+                  rcases hk1 with ⟨hk1a, hk1b⟩
+                  exact ⟨by omega, hk1b⟩
+                · intro hk
+                  rcases hk with ⟨hk1, hk2⟩
+                  constructor
+                  · constructor <;> omega
+                  · omega
+              have hsub2 : Finset.Icc (K + 1) n ⊆ Finset.Icc 1 n := by
+                intro k hk
+                rw [Finset.mem_Icc] at hk ⊢
+                exact ⟨by omega, hk.2⟩
+              calc
+                (∑ k ∈ Finset.Icc 1 n, if K < k then (n : ℝ) * (2 * ((1 : ℝ) / 2)^T) else 0)
+                    = (∑ k ∈ (Finset.Icc 1 n).filter (fun k => K < k), (n : ℝ) * (2 * ((1 : ℝ) / 2)^T)) := by
+                      rw [Finset.sum_filter]
+                _ = ∑ k ∈ Finset.Icc (K + 1) n, (n : ℝ) * (2 * ((1 : ℝ) / 2)^T) := by
+                      rw [hf]
+                _ ≤ ∑ k ∈ Finset.Icc 1 n, (n : ℝ) * (2 * ((1 : ℝ) / 2)^T) := by
+                      exact Finset.sum_le_sum_of_subset_of_nonneg hsub2 (fun k hk hk' => by positivity)
+                _ = (n : ℝ) * (2 * ((1 : ℝ) / 2)^T) * n := by
+                      rw [Finset.sum_const]
+                      rw [Nat.card_Icc]
+                      have hcard : n + 1 - 1 = n := by omega
+                      rw [hcard]
+                      simp [nsmul_eq_mul]
+                      ring
+        _ ≤ (2 : ℝ) := by
+              have hc : (n : ℝ) * (2 * ((1 : ℝ) / 2)^T) * n ≤ 2 := by
+                nlinarith [hdecay]
+              exact hc
+    calc
+      expectedTreapHeight (n := n) = ∑ k ∈ Finset.Icc 1 n, P k := by
+        unfold P
+        exact expectedTreapHeight_eq_sum
+      _ = (∑ k ∈ Finset.Icc 1 n, if k ≤ K then P k else 0) +
+          (∑ k ∈ Finset.Icc 1 n, if K < k then P k else 0) := by
+            rw [← Finset.sum_add_distrib]
+            apply Finset.sum_congr rfl
+            intro k hk
+            by_cases h : k ≤ K
+            · have hK : ¬ K < k := by omega
+              simp [h, hK]
+            · have hK : K < k := by omega
+              simp [h, hK]
+      _ ≤ (K : ℝ) + 2 := by nlinarith [hhead, htail]
+      _ = 12 * (Kh : ℝ) + 2 := by
+            dsimp [K]
+            norm_num
+      _ ≤ 30 * (harmonic n : ℝ) := by
+            have hHreal : H = (harmonic n : ℝ) := by
+              unfold H
+              exact harmonicReal_eq_harmonic n
+            have hK1 : 12 * (Kh : ℝ) + 2 ≤ 12 * H + 14 := by nlinarith [hKh_le]
+            have hK2 : 12 * H + 14 ≤ 30 * H := by nlinarith [hH1]
+            nlinarith [hK1, hK2, hHreal]
 
 set_option linter.unusedTactic false
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ belong.
 | [`workflows/chapter-workflow.md`](workflows/chapter-workflow.md) | End-to-end chapter formalization workflow |
 | [`workflows/lean-fast-verification.md`](workflows/lean-fast-verification.md) | Narrow-to-wide Lean verification loop |
 | [`site-architecture.md`](site-architecture.md) | Verso navigation, rendering, and deployment design |
+| [`randomized-treap-height.md`](randomized-treap-height.md) | Handoff plan for completing the expected-height bound |
 
 ## Documentation Roles
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ belong.
 | [`workflows/chapter-workflow.md`](workflows/chapter-workflow.md) | End-to-end chapter formalization workflow |
 | [`workflows/lean-fast-verification.md`](workflows/lean-fast-verification.md) | Narrow-to-wide Lean verification loop |
 | [`site-architecture.md`](site-architecture.md) | Verso navigation, rendering, and deployment design |
-| [`randomized-treap-height.md`](randomized-treap-height.md) | Handoff plan for completing the expected-height bound |
+| [`randomized-treap-height.md`](randomized-treap-height.md) | Expected-height bound for the randomized treap: `E[height] ≤ 30 · H_n` |
 
 ## Documentation Roles
 

--- a/docs/randomized-treap-height.md
+++ b/docs/randomized-treap-height.md
@@ -1,26 +1,25 @@
-# Randomized treap: completing the expected-height bound
+# Randomized treap: expected-height bound (complete)
 
-Handoff notes for finishing `E[height] ≤ c · H_n = O(log n)` in
+Record of completing `E[height] ≤ c · H_n = O(log n)` in
 `CLRSLean/Extensions/TreapHeight.lean` (prototype, unregistered in
-`literate.toml`).  Written 2026-08-04 on `feat/extensions`.
+`literate.toml`).  Completed 2026-08-04 on `feat/extensions`.
 
-## Goal
+## Goal (achieved)
 
-For the uniform random treap on `n` keys (model in `TreapRandom.lean`), prove:
+For the uniform random treap on `n` keys (model in `TreapRandom.lean`):
 
 ```lean
 theorem expectedTreapHeight_le {n : ℕ} :
-    expectedTreapHeight n ≤ c * (harmonic n : ℝ)
+    expectedTreapHeight (n := n) ≤ 30 * (harmonic n : ℝ)
 ```
 
-for an explicit constant `c`.  `expectedTreapHeight n =
-fintypeExpect (fun σ : PrioPerm n => (treapHeight σ : ℝ))` and
-`treapHeight σ = (Finset.univ.sup (fun b : Fin n => depth σ b))`.
+`expectedTreapHeight n = fintypeExpect (fun σ : PrioPerm n => (treapHeight σ : ℝ))`
+and `treapHeight σ = (Finset.univ.sup (fun b : Fin n => depth σ b))`.
 
 The route is an **exponential tail on the depth of a single key**, then a union
-bound over keys, then a tail sum.
+bound over keys, then a tail sum split at `k ≈ 12 · ⌈H_n⌉`.
 
-## What is already proved (kernel-clean, `[propext, Classical.choice, Quot.sound]`)
+## What is proved (kernel-clean, `[propext, Classical.choice, Quot.sound]`)
 
 All in `TreapHeight.lean` unless noted:
 
@@ -38,62 +37,74 @@ All in `TreapHeight.lean` unless noted:
 - `left_sum_le_harmonicReal` — the left interval sum `Σ_{a<b} 1/|[a,b]| ≤ harmonicReal n`,
   so `P[L(b) ≥ k] ≤ (harmonicReal n)^k / k!` and `harmonicReal n = (harmonic n : ℝ)`.
 
-## Step 1 — right-ancestor tail via reflection
+### Step 1 — right-ancestor tail via reflection (done)
 
-`rightAncestors σ b = |{a | b < a ∧ Ancestor σ a b}|`.  By the order-reversing
-involution, `rightAncestors σ b = leftAncestors (σ * Fin.revPerm) (Fin.revPerm b)`,
-because for `b < a`:
+- `revCompEquiv` — `σ ↦ σ * Fin.revPerm` is an involution (bijection) on
+  `PrioPerm n`.
+- `ancestor_rev_perm` — for `b < a`, `Ancestor (σ * Fin.revPerm) (revPerm a) (revPerm b)
+  ↔ Ancestor σ a b`.
+- `rightAncestors_eq_left_rev` — `rightAncestors σ b = leftAncestors (σ * Fin.revPerm)
+  (revPerm b)` (via `Finset.card_nbij` on the reflecting map `a ↦ revPerm a`).
+- `leftAncestors_tail_le_harmonic` / `rightAncestors_tail_le_harmonic` —
+  `P[L(b) ≥ k] ≤ H_n^k / k!` and `P[R(b) ≥ k] ≤ H_n^k / k!`.
+- `harmonic_pow_div_le` (private) — `S ≤ H_n ∧ S ≥ 0 → S^k/k! ≤ H_n^k/k!`.
 
-- `Fin.revPerm a < Fin.revPerm b`, and
-- `Ancestor (σ * Fin.revPerm) (Fin.revPerm a) (Fin.revPerm b) ↔ Ancestor σ a b`
-  (`σ * Fin.revPerm` applies the reflection to the key first, then reads the old
-  priority; `Equiv.Perm.mul_apply : (f * g) x = f (g x)`).
-
-Then `σ ↦ σ * Fin.revPerm` is a bijection on the sample space, so
-`P[R(b) ≥ k] = P[L(revPerm b) ≥ k]`, and `leftAncestors_tail (Fin.revPerm b) k`
-gives `P[R(b) ≥ k] ≤ (H_n)^k / k!` (the reflected left sum equals the right sum
-by reindexing `a ↦ revPerm a`).
-
-**Gotchas already hit** (in `ancestor_rev_perm`, currently unfinished):
-- `Ancestor` unfolds to `Icc (min a b) (max a b)`.  For `b < a`, first prove and
-  `rw` the conversion `Finset.Icc (min a b) (max a b) = Finset.Icc b a` via
-  `min_eq_left (le_of_lt hab)` / `max_eq_right (le_of_lt hab)`.
-- `Fin.revPerm x` is not definitionally `x.rev`; use `simp [Fin.revPerm_apply]`.
-- `Fin.rev_le_rev (i := i) (j := j) : i.rev ≤ j.rev ↔ j ≤ i` needs explicit
-  `(i := ...) (j := ...)` arguments.
-- `Fin.revPerm` is injective (`Fin.revPerm.injective`); `Fin.rev_lt_iff` gives
+**Gotchas hit and resolved:**
+- `Ancestor` unfolds to `Icc (min a b) (max a b)`; for `b < a` rewrite with
+  `min_eq_left`/`max_eq_right` to `Icc b a` on the `σ`-side and `Icc (rev a) (rev b)`
+  on the reflected side, then bridge the two `∀`-over-interval conditions by
+  `revPerm k ↦ k` reindexing.
+- `Fin.revPerm x` is not definitionally `x.rev`; use `simp [Fin.revPerm_apply]`
+  (and `Fin.rev_rev`, `inv_pow`).
+- `Fin.rev_le_rev`, `Fin.rev_le_iff`, `Fin.le_rev_iff`, `Fin.lt_rev_iff` need
+  explicit `(i := ...) (j := ...)` arguments.
+- `Fin.revPerm` is injective (`Fin.revPerm.injective`); `Fin.rev_lt_rev` gives
   `rev a < rev b ↔ b < a`.
+- `Finset.card_bij` in this Mathlib takes a dependent function; use
+  `Finset.card_nbij` for a plain `α → β`.
 
-## Step 2 — depth tail
+### Step 2 — depth tail (done)
 
 ```lean
 lemma depth_tail {n : ℕ} (b : Fin n) (k : ℕ) :
     fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ depth σ b)) ≤
-      2 * (harmonicReal n)^((k - 1) / 2) / (Nat.factorial ((k - 1) / 2) : ℝ) := ...
+      2 * (harmonicReal n)^((k - 1) / 2) / (Nat.factorial ((k - 1) / 2) : ℝ)
 ```
 
-Split: `depth = L + R + 1`, so `depth ≥ k` implies `L ≥ t` or `R ≥ t` with
-`t = (k-1)/2` (if `L < t` and `R < t` then `L + R ≤ 2t - 2 ≤ k - 2`).  Then
-`P[depth ≥ k] ≤ P[L ≥ t] + P[R ≥ t]`, each `≤ (H_n)^t / t!` by
-`leftAncestors_tail` + `left_sum_le_harmonicReal` and Step 1.
+Split: `depth = L + R + 1`, so `depth ≥ k` forces `L ≥ t` or `R ≥ t` with
+`t = (k-1)/2` (contrapositive: `L < t ∧ R < t` gives `L+R+1 ≤ 2t-1 ≤ k-1`,
+using `2·((k-1)/2) ≤ k`).  Then `P[depth ≥ k] ≤ P[L ≥ t] + P[R ≥ t]`, each
+`≤ H_n^t / t!` via the Step-1 tail lemmas.
 
-## Step 3 — expected height
+### Step 3 — expected height (done)
 
-Union bound over keys, then a tail sum:
+```lean
+theorem expectedTreapHeight_le {n : ℕ} :
+    expectedTreapHeight (n := n) ≤ 30 * (harmonic n : ℝ)
+```
 
-- `P[height ≥ k] ≤ Σ_b P[depth(b) ≥ k] ≤ 2n · (H_n)^t / t!` with `t = (k-1)/2`.
-- `E[height] = Σ_{k≥1} P[height ≥ k] ≤ Σ_{k≥1} min(1, 2n (H_n)^t / t!)`.
-- The head `k ≤ c·H_n` contributes `O(H_n)`; the tail decays (the `t!` dominates
-  once `t ≥ e·H_n`-ish), so the total is `c·H_n + O(1)`.  Use a generous explicit
-  `c` (e.g. `c = 12`) to keep the algebra clean.
+- `depth_le_n`, `treapHeight_le_n` — `depth σ b ≤ n`, `treapHeight σ ≤ n`.
+- `nat_eq_sum_indicator` (private) — `h ≤ n` implies `(h : ℝ) =
+  Σ_{k ∈ Icc 1 n} indicator (k ≤ h)`, giving the tail-sum formula
+  `E[height] = Σ_{k=1}^n P[height ≥ k]` (`expectedTreapHeight_eq_sum`).
+- `height_tail` — union bound: `P[height ≥ k] ≤ Σ_b P[depth(b) ≥ k] ≤
+  n · (2 H_n^t / t!)` with `t = (k-1)/2`.
+- `nat_le_exp_harmonicReal` (private) — `n ≤ exp(H_n)` from
+  `log(n+1) ≤ H_n` (`Real.log_add_one_le_harmonic`).
+- `pow_div_factorial_le_three` (private, with its binomial helpers) — `t^t/t! ≤ 3^t`
+  for `t ≥ 1`, proved from `(1+1/n)^n ≤ 3` via `Nat.choose_le_pow_div` and the
+  `Σ 1/2^i ≤ 2` geometric sum.
+- `pow_div_factorial_le_inv_two` (private) — `H^t/t! ≤ (1/2)^t` when `t ≥ 6H`.
+- `n_sq_mul_inv_pow_le_one` (private) — `n² · (1/2)^(6·Kh) ≤ 1` when
+  `H_n ≤ Kh`, via `n² ≤ exp(2H_n)` and `exp 2 < 64` (`Real.exp_one_lt_d9`).
+- Main: split `Σ_{k=1}^n P[height ≥ k]` at `K = 12·⌈H_n⌉`.  Head `≤ K ≤ 12H_n + 12`;
+  tail: for `k > K`, `t ≥ 6⌈H_n⌉` so `H^t/t! ≤ (1/2)^t ≤ (1/2)^T` with `T = 6⌈H_n⌉`,
+  hence `tail ≤ 2n²·(1/2)^T ≤ 2`; total `≤ 12H_n + 14 ≤ 30 H_n`.
 
-The tail-sum bound needs: `Σ_{t ≥ t₀} 2n(H_n)^t/t! ≤ O(1)` for
-`t₀ ≈ (1+ε)·e·H_n`-ish, via the ratio test / `t! ≥ (t/e)^t`.
+## Verification checklist (all passing)
 
-## Verification checklist
-
-- `lake lean CLRSLean/Extensions/TreapHeight.lean` clean (0 errors/warnings).
-- `#print axioms` on `expectedTreapHeight_le` shows only
+- `lake lean CLRSLean/Extensions/TreapHeight.lean` clean (0 errors).
+- `#print axioms expectedTreapHeight_le` shows only
   `[propext, Classical.choice, Quot.sound]`.
 - `uv run python scripts/check_repository.py` and `lake build CLRSLean` pass.
 - No `sorry`/`admit`.

--- a/docs/randomized-treap-height.md
+++ b/docs/randomized-treap-height.md
@@ -1,0 +1,99 @@
+# Randomized treap: completing the expected-height bound
+
+Handoff notes for finishing `E[height] ≤ c · H_n = O(log n)` in
+`CLRSLean/Extensions/TreapHeight.lean` (prototype, unregistered in
+`literate.toml`).  Written 2026-08-04 on `feat/extensions`.
+
+## Goal
+
+For the uniform random treap on `n` keys (model in `TreapRandom.lean`), prove:
+
+```lean
+theorem expectedTreapHeight_le {n : ℕ} :
+    expectedTreapHeight n ≤ c * (harmonic n : ℝ)
+```
+
+for an explicit constant `c`.  `expectedTreapHeight n =
+fintypeExpect (fun σ : PrioPerm n => (treapHeight σ : ℝ))` and
+`treapHeight σ = (Finset.univ.sup (fun b : Fin n => depth σ b))`.
+
+The route is an **exponential tail on the depth of a single key**, then a union
+bound over keys, then a tail sum.
+
+## What is already proved (kernel-clean, `[propext, Classical.choice, Quot.sound]`)
+
+All in `TreapHeight.lean` unless noted:
+
+- `treapHeight`, `expectedTreapHeight` — the height and its expectation.
+- `depth_eq_left_add_right` — `depth σ b = leftAncestors σ b + rightAncestors σ b + 1`.
+- `maxExtend_uniform` — nested-max independence: given that all keys of `T`
+  are left-ancestors of `b` (each strictly below `c`), the maximum priority of
+  `Icc c b` is equally likely to sit at any of its keys.
+- `leftAncestors_product` — `P[all keys of S are left-ancestors of b] =
+  ∏ a ∈ S, 1/|[a,b]|` (strong induction peeling the largest element).
+- `eSymm_le` — `(∑ s ∈ powersetCard k C, ∏ a ∈ s, x a) ≤ (Σ a ∈ C, x a)^k / k!`.
+- `leftAncestors_tail` — `P[L(b) ≥ k] ≤ (Σ a, if a<b then 1/|[a,b]| else 0)^k / k!`
+  via the union bound over `powersetCard k C` (covered by the product formula)
+  and `eSymm_le`.
+- `left_sum_le_harmonicReal` — the left interval sum `Σ_{a<b} 1/|[a,b]| ≤ harmonicReal n`,
+  so `P[L(b) ≥ k] ≤ (harmonicReal n)^k / k!` and `harmonicReal n = (harmonic n : ℝ)`.
+
+## Step 1 — right-ancestor tail via reflection
+
+`rightAncestors σ b = |{a | b < a ∧ Ancestor σ a b}|`.  By the order-reversing
+involution, `rightAncestors σ b = leftAncestors (σ * Fin.revPerm) (Fin.revPerm b)`,
+because for `b < a`:
+
+- `Fin.revPerm a < Fin.revPerm b`, and
+- `Ancestor (σ * Fin.revPerm) (Fin.revPerm a) (Fin.revPerm b) ↔ Ancestor σ a b`
+  (`σ * Fin.revPerm` applies the reflection to the key first, then reads the old
+  priority; `Equiv.Perm.mul_apply : (f * g) x = f (g x)`).
+
+Then `σ ↦ σ * Fin.revPerm` is a bijection on the sample space, so
+`P[R(b) ≥ k] = P[L(revPerm b) ≥ k]`, and `leftAncestors_tail (Fin.revPerm b) k`
+gives `P[R(b) ≥ k] ≤ (H_n)^k / k!` (the reflected left sum equals the right sum
+by reindexing `a ↦ revPerm a`).
+
+**Gotchas already hit** (in `ancestor_rev_perm`, currently unfinished):
+- `Ancestor` unfolds to `Icc (min a b) (max a b)`.  For `b < a`, first prove and
+  `rw` the conversion `Finset.Icc (min a b) (max a b) = Finset.Icc b a` via
+  `min_eq_left (le_of_lt hab)` / `max_eq_right (le_of_lt hab)`.
+- `Fin.revPerm x` is not definitionally `x.rev`; use `simp [Fin.revPerm_apply]`.
+- `Fin.rev_le_rev (i := i) (j := j) : i.rev ≤ j.rev ↔ j ≤ i` needs explicit
+  `(i := ...) (j := ...)` arguments.
+- `Fin.revPerm` is injective (`Fin.revPerm.injective`); `Fin.rev_lt_iff` gives
+  `rev a < rev b ↔ b < a`.
+
+## Step 2 — depth tail
+
+```lean
+lemma depth_tail {n : ℕ} (b : Fin n) (k : ℕ) :
+    fintypeExpect (fun σ : PrioPerm n => indicator (k ≤ depth σ b)) ≤
+      2 * (harmonicReal n)^((k - 1) / 2) / (Nat.factorial ((k - 1) / 2) : ℝ) := ...
+```
+
+Split: `depth = L + R + 1`, so `depth ≥ k` implies `L ≥ t` or `R ≥ t` with
+`t = (k-1)/2` (if `L < t` and `R < t` then `L + R ≤ 2t - 2 ≤ k - 2`).  Then
+`P[depth ≥ k] ≤ P[L ≥ t] + P[R ≥ t]`, each `≤ (H_n)^t / t!` by
+`leftAncestors_tail` + `left_sum_le_harmonicReal` and Step 1.
+
+## Step 3 — expected height
+
+Union bound over keys, then a tail sum:
+
+- `P[height ≥ k] ≤ Σ_b P[depth(b) ≥ k] ≤ 2n · (H_n)^t / t!` with `t = (k-1)/2`.
+- `E[height] = Σ_{k≥1} P[height ≥ k] ≤ Σ_{k≥1} min(1, 2n (H_n)^t / t!)`.
+- The head `k ≤ c·H_n` contributes `O(H_n)`; the tail decays (the `t!` dominates
+  once `t ≥ e·H_n`-ish), so the total is `c·H_n + O(1)`.  Use a generous explicit
+  `c` (e.g. `c = 12`) to keep the algebra clean.
+
+The tail-sum bound needs: `Σ_{t ≥ t₀} 2n(H_n)^t/t! ≤ O(1)` for
+`t₀ ≈ (1+ε)·e·H_n`-ish, via the ratio test / `t! ≥ (t/e)^t`.
+
+## Verification checklist
+
+- `lake lean CLRSLean/Extensions/TreapHeight.lean` clean (0 errors/warnings).
+- `#print axioms` on `expectedTreapHeight_le` shows only
+  `[propext, Classical.choice, Quot.sound]`.
+- `uv run python scripts/check_repository.py` and `lake build CLRSLean` pass.
+- No `sorry`/`admit`.


### PR DESCRIPTION
Completes the expected-height analysis for the uniform random treap in `CLRSLean/Extensions/TreapHeight.lean`: `E[height] ≤ 30 · H_n = O(log n)`, kernel-checked with axioms `[propext, Classical.choice, Quot.sound]` and no `sorry`.

Three proof layers:

**Step 1 — right-ancestor tail via reflection**
- `revCompEquiv`, `ancestor_rev_perm`, `rightAncestors_eq_left_rev`: the order-reversing involution `σ ↦ σ * Fin.revPerm` turns right-ancestors of `b` into left-ancestors of the reversed key, so `P[R(b) ≥ k] = P[L(rev b) ≥ k]`.
- `leftAncestors_tail_le_harmonic`, `rightAncestors_tail_le_harmonic`: both tails `≤ H_n^k / k!`.

**Step 2 — depth tail**
- `depth_tail`: `depth = L + R + 1`, so `P[depth(b) ≥ k] ≤ 2 · H_n^t / t!` with `t = (k-1)/2`.

**Step 3 — expected height**
- Factorial growth `t^t/t! ≤ 3^t` (from `(1+1/n)^n ≤ 3`), hence `H^t/t! ≤ (1/2)^t` once `t ≥ 6H`.
- `n ≤ exp(H_n)` (via `Real.log_add_one_le_harmonic`) and `n²·(1/2)^T ≤ 1` for `T = 6⌈H_n⌉`.
- Tail-sum formula `E[height] = Σ_{k=1}^n P[height ≥ k]`, union bound `height_tail`, and a head/tail split at `K = 12⌈H_n⌉` give `E[height] ≤ 12H_n + 14 ≤ 30 H_n`.

Also updates `docs/randomized-treap-height.md` (completed-record) and `docs/index.md`. `lake build CLRSLean` and `scripts/check_repository.py` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)