### PR TITLE
feat(ch11): mod-m universal family (Thm 11.5) and successful-search log bound (Thm 11.8)

### DIFF
--- a/CLRSLean/Chapter_11.lean
+++ b/CLRSLean/Chapter_11.lean
@@ -48,14 +48,18 @@ unsuccessful-search cost by {lit}`1/m`.
   {lit}`CLRS.Chapter11.multiplicationHash_lt`,
   {lit}`CLRS.Chapter11.affineHash_isUniversal`,
   {lit}`CLRS.Chapter11.affineHash_expected_collisions`,
-  and {lit}`CLRS.Chapter11.affineHash_expected_search_cost`.
+  {lit}`CLRS.Chapter11.affineHash_expected_search_cost`,
+  and {lit}`CLRS.Chapter11.affineHashMod_isUniversal` (CLRS Theorem 11.5, the
+  general mod-`m` affine family).
 * 11.4 Open addressing: {lit}`proved`.
   Main results: {lit}`CLRS.Chapter11.openSearch_openInsert`,
   {lit}`CLRS.Chapter11.openSearch_eq_false_of_absent`,
   {lit}`CLRS.Chapter11.linearProbe_bijective`,
   {lit}`CLRS.Chapter11.doubleHashProbe_bijective`,
   {lit}`CLRS.Chapter11.expectedUnsuccessfulProbes_le`,
-  and {lit}`CLRS.Chapter11.expectedSuccessfulProbes_le`.
+  {lit}`CLRS.Chapter11.expectedSuccessfulProbes_le`,
+  and {lit}`CLRS.Chapter11.expectedSuccessfulProbes_le_ln` (CLRS Theorem 11.8,
+  logarithmic form).
 * 11.5 Perfect hashing: {lit}`proved`.
   Main results: {lit}`CLRS.Chapter11.perfectSearch_iff_mem`,
   {lit}`CLRS.Chapter11.perfectHash_collision_free_prob_ge_half`,
@@ -76,7 +80,9 @@ formalises the open addressing model with probe sequences (linear, quadratic,
 double hashing) and proves the uniform-hashing expected-probe bounds:
 unsuccessful search and insertion {lit}`≤ 1/(1-α)` (CLRS Theorems 11.6-11.7)
 and successful search `(1/α) · ∑_{j<n} 1/(m-j)` (CLRS Theorem 11.8 harmonic
-form).  Section 11.5 formalises the two-level perfect-hashing scheme: a primary
+form), refined to the closed form `(1/α) · ln(1/(1-α))`
+({lit}`CLRS.Chapter11.expectedSuccessfulProbes_le_ln`).  Section 11.5
+formalises the two-level perfect-hashing scheme: a primary
 hash into `m = n` buckets plus per-bucket secondary tables of size `n_j²`, which
 are collision-free with probability ≥ 1/2 (Theorem 11.9) and collectively use
 expected `O(n)` space (Theorem 11.10).  The remaining gap is RAM / probe-count

--- a/CLRSLean/Chapter_11/Section_11_3_Hash_Functions.lean
+++ b/CLRSLean/Chapter_11/Section_11_3_Hash_Functions.lean
@@ -194,5 +194,353 @@ theorem affineHash_expected_search_cost (p : ℕ) [NeZero p] (hp : p.Prime) {n :
   haveI : Nonempty (ZMod p × ZMod p) := ⟨(0, 0)⟩
   exact universal_expected_search_cost (affineHash p) (affineHash_isUniversal p hp) x k hk
 
+/-! ## The general mod-`m` affine family (CLRS Theorem 11.5, full form)
+
+The exact `m = p` construction above reduces each hash value into `Fin p`.  CLRS
+Theorem 11.5 instead uses a *larger* prime modulus `p` and an outer reduction
+modulo the table size `m ≤ p`: `h_{a,b}(k) = ((a·k + b) mod p) mod m`.  This
+subsection formalises that general family and proves it universal.
+
+The proof is the standard counting argument of CLRS.  For distinct keys `x ≠ y`
+and a nonzero multiplier `a`, the field values `r = a·x + b` and `s = a·y + b`
+differ (else `a·(x - y) = 0` in the field `ZMod p`); the assignment
+`(a,b) ↦ (r,s)` is injective.  A collision modulo `m` therefore corresponds to a
+pair of distinct residues `r ≠ s` with `r ≡ s (mod m)`.  The number of such
+residue pairs in `{0,…,p-1}²` is at most `p·(p-1)/m`, which gives the collision
+probability bound `1/m`. -/
+
+/-- The number of `s < p` strictly greater than `r` and congruent to `r` modulo
+`m` is at most `(p - 1 - r) / m`. -/
+lemma count_congruent_gt_le (p m r : ℕ) (hm : 0 < m) (hr : r < p) :
+    (((Finset.range p).filter (fun s : ℕ => r < s ∧ s % m = r % m)).card : ℕ)
+      ≤ (p - 1 - r) / m := by
+  classical
+  let f : ℕ → ℕ := fun s => (s - r) / m
+  let S : Finset ℕ := (Finset.range p).filter (fun s : ℕ => r < s ∧ s % m = r % m)
+  let T : Finset ℕ := Finset.Icc 1 ((p - 1 - r) / m)
+  have hMt : Set.MapsTo f (S : Set ℕ) (T : Set ℕ) := by
+    intro s hs
+    rcases Finset.mem_filter.mp hs with ⟨hsp, hscond⟩
+    rcases hscond with ⟨hrs, hmod⟩
+    have hslt : s < p := Finset.mem_range.mp hsp
+    have hme : s ≡ r [MOD m] := by
+      change s % m = r % m
+      exact hmod
+    have hle : r ≤ s := le_of_lt hrs
+    have hdvd : m ∣ s - r := (Nat.modEq_iff_dvd' hle).mp hme.symm
+    have hge : m ≤ s - r := by
+      obtain ⟨q, hq⟩ := hdvd
+      have hne : s - r ≠ 0 := by omega
+      have hqpos : 1 ≤ q := by
+        by_contra hqn
+        have hq0 : q = 0 := by omega
+        subst q
+        simp at hq
+        exact hne hq
+      nlinarith
+    have hpos : 1 ≤ (s - r) / m := (Nat.le_div_iff_mul_le hm).mpr (by simpa using hge)
+    have hsub : s - r ≤ p - 1 - r := by
+      have hsp1 : s ≤ p - 1 := by omega
+      exact Nat.sub_le_sub_right hsp1 r
+    have hle2 : (s - r) / m ≤ (p - 1 - r) / m := Nat.div_le_div_right hsub
+    simpa [f, T] using (Finset.mem_Icc.mpr ⟨hpos, hle2⟩)
+  have hInj : (S : Set ℕ).InjOn f := by
+    intro s hs t ht hf
+    have hmes : s ≡ r [MOD m] := by
+      have hmod : s % m = r % m := (Finset.mem_filter.mp hs).2.2
+      change s % m = r % m
+      exact hmod
+    have hmet : t ≡ r [MOD m] := by
+      have hmod : t % m = r % m := (Finset.mem_filter.mp ht).2.2
+      change t % m = r % m
+      exact hmod
+    have hsle : r ≤ s := le_of_lt (Finset.mem_filter.mp hs).2.1
+    have htle : r ≤ t := le_of_lt (Finset.mem_filter.mp ht).2.1
+    have hdvdS : m ∣ s - r := (Nat.modEq_iff_dvd' hsle).mp hmes.symm
+    have hdvdT : m ∣ t - r := (Nat.modEq_iff_dvd' htle).mp hmet.symm
+    have hcal : s - r = t - r := by
+      calc s - r = (s - r) / m * m := by rw [Nat.div_mul_cancel hdvdS]
+        _ = (t - r) / m * m := by
+              change f s * m = f t * m
+              rw [hf]
+        _ = t - r := by rw [Nat.div_mul_cancel hdvdT]
+    omega
+  have hle := Finset.card_le_card_of_injOn f hMt hInj
+  have hT : T.card = (p - 1 - r) / m := by
+    simp [T]
+  rwa [hT] at hle
+
+/-- The number of `s < p` strictly less than `r` and congruent to `r` modulo
+`m` is at most `r / m`. -/
+lemma count_congruent_lt_le (p m r : ℕ) (hm : 0 < m) (hr : r < p) :
+    (((Finset.range p).filter (fun s : ℕ => s < r ∧ s % m = r % m)).card : ℕ)
+      ≤ r / m := by
+  classical
+  let f : ℕ → ℕ := fun s => (r - s) / m
+  let S : Finset ℕ := (Finset.range p).filter (fun s : ℕ => s < r ∧ s % m = r % m)
+  let T : Finset ℕ := Finset.Icc 1 (r / m)
+  have hMt : Set.MapsTo f (S : Set ℕ) (T : Set ℕ) := by
+    intro s hs
+    rcases Finset.mem_filter.mp hs with ⟨hsp, hscond⟩
+    rcases hscond with ⟨hsr, hmod⟩
+    have hme : s ≡ r [MOD m] := by
+      change s % m = r % m
+      exact hmod
+    have hle : s ≤ r := le_of_lt hsr
+    have hdvd : m ∣ r - s := (Nat.modEq_iff_dvd' hle).mp hme
+    have hge : m ≤ r - s := by
+      obtain ⟨q, hq⟩ := hdvd
+      have hne : r - s ≠ 0 := by omega
+      have hqpos : 1 ≤ q := by
+        by_contra hqn
+        have hq0 : q = 0 := by omega
+        subst q
+        simp at hq
+        exact hne hq
+      nlinarith
+    have hpos : 1 ≤ (r - s) / m := (Nat.le_div_iff_mul_le hm).mpr (by simpa using hge)
+    have hle2 : (r - s) / m ≤ r / m := Nat.div_le_div_right (Nat.sub_le r s)
+    simpa [f, T] using (Finset.mem_Icc.mpr ⟨hpos, hle2⟩)
+  have hInj : (S : Set ℕ).InjOn f := by
+    intro s hs t ht hf
+    have hmes : s ≡ r [MOD m] := by
+      have hmod : s % m = r % m := (Finset.mem_filter.mp hs).2.2
+      change s % m = r % m
+      exact hmod
+    have hmet : t ≡ r [MOD m] := by
+      have hmod : t % m = r % m := (Finset.mem_filter.mp ht).2.2
+      change t % m = r % m
+      exact hmod
+    have hsle : s ≤ r := le_of_lt (Finset.mem_filter.mp hs).2.1
+    have htle : t ≤ r := le_of_lt (Finset.mem_filter.mp ht).2.1
+    have hdvdS : m ∣ r - s := (Nat.modEq_iff_dvd' hsle).mp hmes
+    have hdvdT : m ∣ r - t := (Nat.modEq_iff_dvd' htle).mp hmet
+    have hcal : r - s = r - t := by
+      calc r - s = (r - s) / m * m := by rw [Nat.div_mul_cancel hdvdS]
+        _ = (r - t) / m * m := by
+              change f s * m = f t * m
+              rw [hf]
+        _ = r - t := by rw [Nat.div_mul_cancel hdvdT]
+    omega
+  have hle := Finset.card_le_card_of_injOn f hMt hInj
+  have hT : T.card = r / m := by
+    simp [T]
+  rwa [hT] at hle
+
+/-- The number of pairs `(r, s)` with `r < p`, `s < p`, `r ≠ s`, and
+`r % m = s % m` is at most `p·(p-1)/m`. -/
+lemma congruentPair_count_le (p m : ℕ) (hm : 0 < m) :
+    (((Finset.range p).product (Finset.range p)).filter
+        (fun rs : ℕ × ℕ => rs.1 ≠ rs.2 ∧ rs.1 % m = rs.2 % m)).card
+      ≤ (p : ℝ) * (p - 1 : ℝ) / (m : ℝ) := by
+  classical
+  let S : ℕ → Finset ℕ := fun r =>
+    (Finset.range p).filter (fun s : ℕ => s ≠ r ∧ s % m = r % m)
+  have hper : ∀ r ∈ Finset.range p, ((S r).card : ℝ) ≤ (p - 1 : ℝ) / (m : ℝ) := by
+    intro r hr
+    have hrp : r < p := Finset.mem_range.mp hr
+    let Sneg : Finset ℕ := (Finset.range p).filter (fun s : ℕ => s < r ∧ s % m = r % m)
+    let Spos : Finset ℕ := (Finset.range p).filter (fun s : ℕ => r < s ∧ s % m = r % m)
+    have hsplit : S r = Sneg ∪ Spos := by
+      ext s
+      constructor
+      · intro hs
+        rcases Finset.mem_filter.mp hs with ⟨hsp, hne, hmod⟩
+        have hslt : s < r ∨ r < s := by omega
+        rw [Finset.mem_union]
+        rcases hslt with hslt | hslt
+        · exact Or.inl (Finset.mem_filter.mpr ⟨hsp, ⟨hslt, hmod⟩⟩)
+        · exact Or.inr (Finset.mem_filter.mpr ⟨hsp, ⟨hslt, hmod⟩⟩)
+      · intro hs
+        rw [Finset.mem_union] at hs
+        rcases hs with hs | hs
+        · rcases Finset.mem_filter.mp hs with ⟨hsp, hsr, hmod⟩
+          exact Finset.mem_filter.mpr ⟨hsp, ⟨ne_of_lt hsr, hmod⟩⟩
+        · rcases Finset.mem_filter.mp hs with ⟨hsp, hsr, hmod⟩
+          exact Finset.mem_filter.mpr ⟨hsp, ⟨ne_of_gt hsr, hmod⟩⟩
+    have hd : Disjoint Sneg Spos := by
+      rw [Finset.disjoint_left]
+      intro s hsneg hspos
+      simp [Sneg, Spos] at hsneg hspos
+      omega
+    have hcard : (S r).card = Sneg.card + Spos.card := by
+      rw [hsplit, Finset.card_union_of_disjoint hd]
+    have hb1 : (Spos.card : ℝ) ≤ (p - 1 - r : ℝ) / (m : ℝ) := by
+      calc
+        (Spos.card : ℝ) ≤ (((p - 1 - r) / m : ℕ) : ℝ) := by
+          exact_mod_cast (count_congruent_gt_le p m r hm hrp)
+        _ ≤ (p - 1 - r : ℝ) / (m : ℝ) := by
+          have hnum : ((p - 1 - r : ℕ) : ℝ) = (p - 1 - r : ℝ) := by
+            rw [Nat.cast_sub (by omega : r ≤ p - 1)]
+            rw [Nat.cast_sub (by omega : 1 ≤ p), Nat.cast_one]
+          rw [← hnum]
+          exact Nat.cast_div_le
+    have hb2 : (Sneg.card : ℝ) ≤ (r : ℝ) / (m : ℝ) := by
+      calc
+        (Sneg.card : ℝ) ≤ ((r / m : ℕ) : ℝ) := by
+          exact_mod_cast (count_congruent_lt_le p m r hm hrp)
+        _ ≤ (r : ℝ) / (m : ℝ) := Nat.cast_div_le
+    have hdiv : (r : ℝ) / (m : ℝ) + (p - 1 - r : ℝ) / (m : ℝ) = (p - 1 : ℝ) / (m : ℝ) := by
+      rw [← add_div]
+      ring
+    rw [hcard, Nat.cast_add]
+    calc (Sneg.card : ℝ) + (Spos.card : ℝ)
+        ≤ (r : ℝ) / (m : ℝ) + (p - 1 - r : ℝ) / (m : ℝ) := add_le_add hb2 hb1
+      _ = (p - 1 : ℝ) / (m : ℝ) := hdiv
+  have hPsubset : (((Finset.range p).product (Finset.range p)).filter
+        (fun rs : ℕ × ℕ => rs.1 ≠ rs.2 ∧ rs.1 % m = rs.2 % m))
+      ⊆ (Finset.range p).biUnion (fun r : ℕ => ({r} : Finset ℕ).product (S r)) := by
+    intro rs hrs
+    rcases Finset.mem_filter.mp hrs with ⟨hrsprod, hne, hmod⟩
+    rw [Finset.product_eq_sprod, Finset.mem_product] at hrsprod
+    rcases hrsprod with ⟨hrp, hsp⟩
+    rw [Finset.mem_biUnion]
+    refine ⟨rs.1, hrp, ?_⟩
+    rw [Finset.product_eq_sprod, Finset.mem_product]
+    refine ⟨Finset.mem_singleton.mpr rfl, ?_⟩
+    rw [Finset.mem_filter]
+    exact ⟨hsp, hne.symm, hmod.symm⟩
+  have hcb := Finset.card_biUnion_le (s := Finset.range p)
+    (t := fun r : ℕ => ({r} : Finset ℕ).product (S r))
+  calc
+    ((((Finset.range p).product (Finset.range p)).filter
+        (fun rs : ℕ × ℕ => rs.1 ≠ rs.2 ∧ rs.1 % m = rs.2 % m)).card : ℝ)
+        ≤ (((Finset.range p).biUnion (fun r : ℕ => ({r} : Finset ℕ).product (S r))).card : ℝ) := by
+            exact_mod_cast (Finset.card_le_card hPsubset)
+    _ ≤ (∑ r ∈ (Finset.range p : Finset ℕ), ((({r} : Finset ℕ).product (S r)).card : ℝ)) := by
+            exact_mod_cast hcb
+    _ = (∑ r ∈ (Finset.range p : Finset ℕ), ((S r).card : ℝ)) := by
+            apply Finset.sum_congr rfl
+            intro r hr
+            simp [Finset.card_product]
+    _ ≤ (∑ r ∈ (Finset.range p : Finset ℕ), (p - 1 : ℝ) / (m : ℝ)) := by
+            apply Finset.sum_le_sum
+            intro r hr
+            exact hper r hr
+    _ = (p : ℝ) * (p - 1 : ℝ) / (m : ℝ) := by
+            rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul]
+            ring
+
+/-- The **general mod-`m` affine family** of CLRS Theorem 11.5:
+`h_{a,b}(k) = ((a·k + b) mod p) mod m`, computed in the field `ZMod p` and then
+reduced modulo the table size `m`.  The index `(a,b)` ranges over `ZMod p ×
+ZMod p` with `a ≠ 0`; the codomain is `Fin m`. -/
+def affineHashMod (p m : ℕ) [NeZero p] [NeZero m]
+    (t : {a : ZMod p // a ≠ 0} × ZMod p) (k : ZMod p) : Fin m :=
+  ⟨ZMod.val (t.1.1 * k + t.2) % m, Nat.mod_lt _ (NeZero.pos m)⟩
+
+/--
+**Theorem (CLRS Theorem 11.5, full mod-`m` form).**  The general affine family
+{lit}`h_{a,b}(k) = ((a·k + b) mod p) mod m` (`a ≠ 0`) is universal: any two
+distinct keys collide under a uniformly random member with probability at most
+{lit}`1/m`.  This refines the exact `m = p` construction
+{lit}`affineHash_isUniversal` to arbitrary table sizes `m ≤ p`.
+-/
+theorem affineHashMod_isUniversal (p m : ℕ) [NeZero p] [NeZero m] (hp : p.Prime) :
+    IsUniversal (affineHashMod p m) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  intro x y hxy
+  let B : Finset ({a : ZMod p // a ≠ 0} × ZMod p) :=
+    (Finset.univ : Finset ({a : ZMod p // a ≠ 0} × ZMod p)).filter
+      (fun t => affineHashMod p m t x = affineHashMod p m t y)
+  have hExpect :
+      fintypeExpect (fun t : {a : ZMod p // a ≠ 0} × ZMod p =>
+        indicator (affineHashMod p m t x = affineHashMod p m t y))
+        = (B.card : ℝ) / (Fintype.card ({a : ZMod p // a ≠ 0} × ZMod p) : ℝ) := by
+    unfold fintypeExpect indicator
+    have hsum : (∑ t : {a : ZMod p // a ≠ 0} × ZMod p,
+        (if affineHashMod p m t x = affineHashMod p m t y then (1 : ℝ) else 0))
+        = (B.card : ℝ) := by
+      simp [B]
+    rw [hsum]
+  rw [hExpect]
+  let φ : ({a : ZMod p // a ≠ 0} × ZMod p) → ℕ × ℕ := fun t =>
+    (ZMod.val (t.1.1 * x + t.2), ZMod.val (t.1.1 * y + t.2))
+  have hφinj : (B : Set ({a : ZMod p // a ≠ 0} × ZMod p)).InjOn φ := by
+    intro t1 ht1 t2 ht2 hφ
+    rcases t1 with ⟨a1, b1⟩
+    rcases t2 with ⟨a2, b2⟩
+    have hfst : ZMod.val (a1.1 * x + b1) = ZMod.val (a2.1 * x + b2) :=
+      congrArg Prod.fst hφ
+    have hsnd : ZMod.val (a1.1 * y + b1) = ZMod.val (a2.1 * y + b2) :=
+      congrArg Prod.snd hφ
+    have h1 : a1.1 * x + b1 = a2.1 * x + b2 := ZMod.val_injective p hfst
+    have h2 : a1.1 * y + b1 = a2.1 * y + b2 := ZMod.val_injective p hsnd
+    have hxy0 : x - y ≠ 0 := sub_ne_zero.mpr hxy
+    have hdiff : a1.1 - a2.1 = 0 := by
+      have hsub : a1.1 * (x - y) = a2.1 * (x - y) := by
+        calc a1.1 * (x - y) = (a1.1 * x + b1) - (a1.1 * y + b1) := by ring
+          _ = (a2.1 * x + b2) - (a2.1 * y + b2) := by rw [h1, h2]
+          _ = a2.1 * (x - y) := by ring
+      have hmul : (a1.1 - a2.1) * (x - y) = 0 := by
+        calc (a1.1 - a2.1) * (x - y) = a1.1 * (x - y) - a2.1 * (x - y) := by ring
+          _ = 0 := by rw [hsub, sub_self]
+      exact (mul_eq_zero.mp hmul).resolve_right hxy0
+    have ha : a1.1 = a2.1 := sub_eq_zero.mp hdiff
+    have hb : b1 = b2 := by
+      have hx : a1.1 * x + b1 = a1.1 * x + b2 := by
+        rwa [← ha] at h1
+      exact add_left_cancel hx
+    exact Prod.ext (Subtype.ext ha) hb
+  let C : Finset (ℕ × ℕ) :=
+    (Finset.range p).product (Finset.range p) |>.filter
+      (fun rs : ℕ × ℕ => rs.1 ≠ rs.2 ∧ rs.1 % m = rs.2 % m)
+  have hIm : B.image φ ⊆ C := by
+    intro rs hrs
+    rcases (Finset.mem_image.mp hrs) with ⟨t, htB, hφt⟩
+    rcases t with ⟨a, b⟩
+    rw [← hφt]
+    change (ZMod.val (a.1 * x + b), ZMod.val (a.1 * y + b)) ∈ C
+    have hcoll : affineHashMod p m ⟨a, b⟩ x = affineHashMod p m ⟨a, b⟩ y :=
+      (Finset.mem_filter.mp htB).2
+    simp [C]
+    constructor
+    · constructor
+      · exact ZMod.val_lt (a.1 * x + b)
+      · exact ZMod.val_lt (a.1 * y + b)
+    · constructor
+      · intro hval
+        have h : a.1 * x + b = a.1 * y + b := ZMod.val_injective p hval
+        have h' : a.1 * (x - y) = 0 := by
+          calc a.1 * (x - y) = (a.1 * x + b) - (a.1 * y + b) := by ring
+            _ = 0 := by rw [h, sub_self]
+        have hxy0 : x - y ≠ 0 := sub_ne_zero.mpr hxy
+        exact a.2 ((mul_eq_zero.mp h').resolve_right hxy0)
+      · have hfin : (⟨ZMod.val (a.1 * x + b) % m, Nat.mod_lt _ (NeZero.pos m)⟩ : Fin m)
+            = ⟨ZMod.val (a.1 * y + b) % m, Nat.mod_lt _ (NeZero.pos m)⟩ := by
+          simpa [affineHashMod] using hcoll
+        exact congrArg Fin.val hfin
+  have hcardIm : (B.image φ).card = B.card := Finset.card_image_of_injOn hφinj
+  have hleC : B.card ≤ C.card := by
+    rw [← hcardIm]
+    exact Finset.card_le_card hIm
+  have hBcard : (B.card : ℝ) ≤ (p : ℝ) * (p - 1 : ℝ) / (m : ℝ) := by
+    have hCbound : (C.card : ℝ) ≤ (p : ℝ) * (p - 1 : ℝ) / (m : ℝ) :=
+      congruentPair_count_le p m (NeZero.pos m)
+    exact le_trans (by exact_mod_cast hleC) hCbound
+  have hIcard : (Fintype.card ({a : ZMod p // a ≠ 0} × ZMod p) : ℝ) = (p : ℝ) * (p - 1 : ℝ) := by
+    rw [Fintype.card_prod]
+    have hne0 : Fintype.card {a : ZMod p // a = 0} = 1 := by
+      rw [Fintype.card_subtype_eq]
+    have h1 : Fintype.card {a : ZMod p // a ≠ 0} = p - 1 := by
+      have hc := Fintype.card_subtype_compl (p := fun a : ZMod p => a = 0)
+      rw [hne0, ZMod.card] at hc
+      simpa [ne_eq, eq_comm] using hc
+    rw [h1, ZMod.card]
+    rw [Nat.cast_mul]
+    rw [Nat.cast_sub hp.one_le]
+    ring
+  have hmne : (m : ℝ) ≠ 0 := by exact_mod_cast (NeZero.ne m)
+  have hIpos : 0 < (p : ℝ) * (p - 1 : ℝ) := by
+    have hp2 : (2 : ℝ) ≤ (p : ℝ) := by exact_mod_cast hp.two_le
+    nlinarith
+  have hdiv : (B.card : ℝ) / ((p : ℝ) * (p - 1 : ℝ)) ≤ 1 / (m : ℝ) := by
+    rw [div_le_iff₀ hIpos]
+    calc (B.card : ℝ) ≤ (p : ℝ) * (p - 1 : ℝ) / (m : ℝ) := hBcard
+      _ = (1 : ℝ) / (m : ℝ) * ((p : ℝ) * (p - 1 : ℝ)) := by
+        field_simp [hmne]
+  rw [hIcard]
+  exact hdiv
+
 end Chapter11
 end CLRS

--- a/CLRSLean/Chapter_11/Section_11_4_Open_Addressing.lean
+++ b/CLRSLean/Chapter_11/Section_11_4_Open_Addressing.lean
@@ -40,6 +40,9 @@ Main results:
   - Theorem {lit}`expectedSuccessfulProbes_le`: expected successful-search probes
     `≤ (1/α) * ∑_{j<n} 1/(m-j) = (1/α)(H_m - H_{m-n})`, the harmonic form of
     CLRS Theorem 11.8.
+  - Theorem {lit}`expectedSuccessfulProbes_le_ln`: expected successful-search probes
+    `≤ (1/α) * ln(1/(1-α))`, the logarithmic (closed-form) version of
+    CLRS Theorem 11.8.
 
 Status: `proved` for the functional model, the probe schemes, and the
 uniform-hashing expected-probe bounds.
@@ -56,9 +59,8 @@ Notation conventions used in this section:
 Current gaps: the expected-probe values are the tail-sum
 `E[X] = ∑_{i≥0} P[X > i]`, with the tail probabilities `probeTail` the standard
 uniform-hashing without-replacement products.  Deriving those tails from an
-explicit permutation sample space (via `Fintype` counting), and the closed-form
-`ln(1/(1-α))` integral bound refining the harmonic sum, are deferred refinements;
-RAM / cache-cost semantics remain out of scope (epic #28).
+explicit permutation sample space (via `Fintype` counting) is a deferred
+refinement; RAM / cache-cost semantics remain out of scope (epic #28).
 -/
 
 namespace CLRS
@@ -400,8 +402,8 @@ noncomputable def expectedSuccessfulProbes (m n : ℕ) : ℝ :=
 /-- **Theorem 11.8 (successful search), harmonic form.**  Under uniform hashing
 the expected number of probes in a successful search is at most
 `(1/α) * ∑_{j<n} 1/(m-j) = (1/α)(H_m - H_{m-n})` (`α = n/m`).  The stated
-harmonic-sum bound is proved; the classical `(1/α) ln(1/(1-α))` follows from
-`H_m - H_{m-n} ≤ ln(m/(m-n))` and is not formalised here. -/
+harmonic-sum bound is proved; the classical `(1/α) ln(1/(1-α))` follows via
+{lit}`sum_inv_shift_le_log` and is proved as {lit}`expectedSuccessfulProbes_le_ln`. -/
 theorem expectedSuccessfulProbes_le (m n : ℕ) (hn : n ≤ m) (hnpos : 0 < n) :
     expectedSuccessfulProbes m n
       ≤ (1 / openLoadFactor m n) * ∑ j ∈ Finset.range n, 1 / ((m : ℝ) - (j : ℝ)) := by
@@ -429,6 +431,103 @@ theorem expectedSuccessfulProbes_le (m n : ℕ) (hn : n ≤ m) (hnpos : 0 < n) :
     rw [openLoadFactor, one_div_div]; ring
   rw [hfin] at step1
   exact step1
+
+/-- The **free-capacity identity** `1/(1 - n/m) = m/(m-n)` for a non-full table
+(`n < m`): the reciprocal of the free capacity equals the ratio of the table size
+to the remaining slots.  This is the `ln(1/(1-α)) = ln(m/(m-n))` identity used to
+pass from the harmonic sum bound to the logarithmic form of Theorem 11.8. -/
+lemma openLoadFactor_inv_eq (m n : ℕ) (hn : n < m) :
+    (1 : ℝ) / (1 - (n : ℝ) / (m : ℝ)) = (m : ℝ) / ((m - n : ℕ) : ℝ) := by
+  have hmpos : (0 : ℝ) < (m : ℝ) := by exact_mod_cast (lt_of_le_of_lt (Nat.zero_le n) hn)
+  have hmne : (m : ℝ) ≠ 0 := ne_of_gt hmpos
+  have hmncast : ((m - n : ℕ) : ℝ) = (m : ℝ) - (n : ℝ) := by
+    rw [Nat.cast_sub (le_of_lt hn)]
+  rw [hmncast]
+  have hsub : (m : ℝ) - (n : ℝ) ≠ 0 := by
+    have : (n : ℝ) < (m : ℝ) := by exact_mod_cast hn
+    linarith
+  have hαne : 1 - (n : ℝ) / (m : ℝ) ≠ 0 := by
+    have hα : (n : ℝ) / (m : ℝ) < 1 := (div_lt_one hmpos).2 (by exact_mod_cast hn)
+    linarith
+  field_simp [hmne, hsub, hαne]
+
+/-- **Harmonic-sum bound.**  For `n < m`, `∑_{j<n} 1/(m-j) ≤ ln(m/(m-n))`: each
+term `1/(m-j)` is at most `ln((m-j)/(m-j-1))` (from the bound
+`ln(1+x) ≥ x/(1+x)` with `x = 1/(m-j-1)`), and the resulting sum telescopes to
+`ln(m/(m-n))`.  This is the integral bound used to obtain the logarithmic form of
+Theorem 11.8 from its harmonic form. -/
+lemma sum_inv_shift_le_log (m n : ℕ) (hn : n < m) :
+    (∑ j ∈ Finset.range n, (1 : ℝ) / ((m : ℝ) - (j : ℝ)))
+      ≤ Real.log ((m : ℝ) / ((m - n : ℕ) : ℝ)) := by
+  classical
+  have hterm (j : ℕ) (hj : j < n) : (1 : ℝ) / ((m : ℝ) - (j : ℝ))
+      ≤ Real.log (((m : ℝ) - (j : ℝ)) / (((m : ℝ) - (j : ℝ)) - 1)) := by
+    have hsucc : j + 1 < m := by omega
+    have hjm1 : (j : ℝ) + 1 < (m : ℝ) := by exact_mod_cast hsucc
+    have hden : 0 < ((m : ℝ) - (j : ℝ)) - 1 := by linarith
+    have hnum : 0 < (m : ℝ) - (j : ℝ) := by linarith
+    have hx : 0 < ((m : ℝ) - (j : ℝ)) / (((m : ℝ) - (j : ℝ)) - 1) := div_pos hnum hden
+    have h := Real.one_sub_inv_le_log_of_pos hx
+    have hlin : (1 : ℝ) - (((m : ℝ) - (j : ℝ)) / (((m : ℝ) - (j : ℝ)) - 1))⁻¹
+        = (1 : ℝ) / ((m : ℝ) - (j : ℝ)) := by
+      field_simp [hnum.ne', hden.ne']
+      ring
+    rwa [hlin] at h
+  calc
+    (∑ j ∈ Finset.range n, (1 : ℝ) / ((m : ℝ) - (j : ℝ)))
+        ≤ ∑ j ∈ Finset.range n,
+            Real.log (((m : ℝ) - (j : ℝ)) / (((m : ℝ) - (j : ℝ)) - 1)) := by
+            apply Finset.sum_le_sum
+            intro j hj
+            exact hterm j (Finset.mem_range.mp hj)
+    _ = Real.log ((m : ℝ) / ((m - n : ℕ) : ℝ)) := by
+          have hsplit : ∀ j ∈ Finset.range n,
+              Real.log (((m : ℝ) - (j : ℝ)) / (((m : ℝ) - (j : ℝ)) - 1))
+                = Real.log ((m : ℝ) - (j : ℝ)) - Real.log (((m : ℝ) - (j : ℝ)) - 1) := by
+            intro j hj
+            have hjn : j < n := Finset.mem_range.mp hj
+            have hsucc : j + 1 < m := by omega
+            have hjm1 : (j : ℝ) + 1 < (m : ℝ) := by exact_mod_cast hsucc
+            have hden : 0 < ((m : ℝ) - (j : ℝ)) - 1 := by linarith
+            have hnum : 0 < (m : ℝ) - (j : ℝ) := by linarith
+            exact Real.log_div hnum.ne' hden.ne'
+          rw [Finset.sum_congr rfl hsplit]
+          have htel : (∑ j ∈ Finset.range n,
+                (Real.log ((m : ℝ) - (j : ℝ)) - Real.log (((m : ℝ) - (j : ℝ)) - 1)))
+              = Real.log ((m : ℝ) - (0 : ℝ)) - Real.log ((m : ℝ) - (n : ℝ)) := by
+            simpa [Nat.cast_add, Nat.cast_one, sub_add_eq_sub_sub] using
+              (Finset.sum_range_sub' (f := fun i : ℕ => Real.log ((m : ℝ) - (i : ℝ))) n)
+          rw [htel, sub_zero, ← Nat.cast_sub (le_of_lt hn)]
+          have hm : (m : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt (lt_of_le_of_lt (Nat.zero_le n) hn))
+          have hmn : ((m - n : ℕ) : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt (Nat.sub_pos_of_lt hn))
+          rw [← Real.log_div hm hmn]
+
+/-- **Theorem 11.8 (successful search), logarithmic form.**  Under uniform
+hashing the expected number of probes in a successful search is at most
+`(1/α) * ln(1/(1-α))` (`α = n/m < 1`), obtained from the harmonic form
+{lit}`expectedSuccessfulProbes_le` via the integral bound
+`∑_{j<n} 1/(m-j) ≤ ln(m/(m-n)) = ln(1/(1-α))`. -/
+theorem expectedSuccessfulProbes_le_ln (m n : ℕ) (hn : n < m) (hnpos : 0 < n) :
+    expectedSuccessfulProbes m n
+      ≤ (1 / openLoadFactor m n) * Real.log (1 / (1 - openLoadFactor m n)) := by
+  have hharm := expectedSuccessfulProbes_le m n (le_of_lt hn) hnpos
+  have hlog : (∑ j ∈ Finset.range n, (1 : ℝ) / ((m : ℝ) - (j : ℝ)))
+      ≤ Real.log ((m : ℝ) / ((m - n : ℕ) : ℝ)) := sum_inv_shift_le_log m n hn
+  have hαpos : 0 < openLoadFactor m n := by
+    rw [openLoadFactor]
+    exact div_pos (by exact_mod_cast hnpos) (by exact_mod_cast (lt_of_le_of_lt (Nat.zero_le n) hn))
+  have hαnonneg : 0 ≤ 1 / openLoadFactor m n := by
+    exact one_div_nonneg.mpr (le_of_lt hαpos)
+  have hconv : Real.log (1 / (1 - openLoadFactor m n)) = Real.log ((m : ℝ) / ((m - n : ℕ) : ℝ)) := by
+    congr 1
+    rw [openLoadFactor]
+    exact openLoadFactor_inv_eq m n hn
+  have hmult := mul_le_mul_of_nonneg_left hlog hαnonneg
+  calc
+    expectedSuccessfulProbes m n
+        ≤ (1 / openLoadFactor m n) * ∑ j ∈ Finset.range n, 1 / ((m : ℝ) - (j : ℝ)) := hharm
+    _ ≤ (1 / openLoadFactor m n) * Real.log ((m : ℝ) / ((m - n : ℕ) : ℝ)) := hmult
+    _ = (1 / openLoadFactor m n) * Real.log (1 / (1 - openLoadFactor m n)) := by rw [hconv]
 
 end Chapter11
 end CLRS

--- a/docs/proof-map.md
+++ b/docs/proof-map.md
@@ -1422,6 +1422,34 @@ underflow reported as `none`.
   (CLRS Theorem 11.3) from the universality hypothesis alone.
 - Current gap: RAM/probe-count operational semantics.
 
+### Section 11.3 - Hash functions
+
+- Lean source: `CLRSLean/Chapter_11/Section_11_3_Hash_Functions.lean`
+- Status: `proved`
+- Main proved theorems:
+  - `CLRS.Chapter11.divisionHash_lt`, `CLRS.Chapter11.multiplicationHash_lt`: range bounds for the division and multiplication methods (CLRS §11.3, equations (11.1)-(11.3))
+  - `CLRS.Chapter11.affineHash_isUniversal`: the exact `m = p` affine family over `ZMod p` is universal (CLRS Theorem 11.5, special case)
+  - `CLRS.Chapter11.affineHash_expected_collisions`, `CLRS.Chapter11.affineHash_expected_search_cost`: expected collision and search-cost bounds for the affine family
+  - `CLRS.Chapter11.affineHashMod_isUniversal`: the general mod-`m` affine family `h_{a,b}(k) = ((a·k + b) mod p) mod m` (`a ≠ 0`) is universal for any table size `m ≤ p` (CLRS Theorem 11.5, full form)
+  - `CLRS.Chapter11.count_congruent_gt_le`, `CLRS.Chapter11.count_congruent_lt_le`, `CLRS.Chapter11.congruentPair_count_le`: residue-pair counting lemmas bounding the number of distinct residue pairs colliding modulo `m`
+- Proof pattern: `affineHashMod_isUniversal` injectively maps colliding index pairs `(a,b)` into residue pairs `(r,s)` with `r ≠ s` and `r ≡ s (mod m)`, bounded by `p(p-1)/m`; the exact `m = p` case needs only the injectivity argument.
+- Current gap: none for the represented interface; concrete bit-level hash-cost semantics remain an optional low-level refinement.
+
+### Section 11.4 - Open addressing
+
+- Lean source: `CLRSLean/Chapter_11/Section_11_4_Open_Addressing.lean`
+- Status: `proved`
+- Main proved theorems:
+  - `CLRS.Chapter11.openSearch_eq_false_of_absent`, `CLRS.Chapter11.openSearch_openInsert`: functional-model correctness (absent key not found, inserted key found)
+  - `CLRS.Chapter11.linearProbe_bijective`, `CLRS.Chapter11.doubleHashProbe_bijective`, `CLRS.Chapter11.quadraticProbe_zero`: the probe schemes of CLRS §11.4, equations (11.5)-(11.7)
+  - `CLRS.Chapter11.probeTail_le_pow`: the per-factor uniform-hashing tail bound `(n-j)/(m-j) ≤ n/m`
+  - `CLRS.Chapter11.expectedUnsuccessfulProbes_le` (Theorem 11.6): expected unsuccessful-search probes `≤ 1/(1-α)`
+  - `CLRS.Chapter11.expectedInsertionProbes_le` (Corollary 11.7)
+  - `CLRS.Chapter11.expectedSuccessfulProbes_le` (Theorem 11.8, harmonic form): `≤ (1/α) * ∑_{j<n} 1/(m-j) = (1/α)(H_m - H_{m-n})`
+  - `CLRS.Chapter11.expectedSuccessfulProbes_le_ln` (Theorem 11.8, logarithmic form): `≤ (1/α) * ln(1/(1-α))`, obtained from the harmonic form via `CLRS.Chapter11.sum_inv_shift_le_log` (`∑_{j<n} 1/(m-j) ≤ ln(m/(m-n))`)
+- Proof pattern: tail-sum expectation `E[X] = ∑_i P[X > i]` with the without-replacement tail products `probeTail`, bounded by the geometric series; the successful-search bound averages the unsuccessful-search costs over the `n` insertion times; the logarithmic form telescopes `∑_{j<n} ln((m-j)/(m-j-1))` from the bound `ln(1+x) ≥ x/(1+x)`.
+- Current gap: deriving the tail probabilities from an explicit permutation sample space (via `Fintype` counting); RAM / probe-count cost semantics remain optional low-level refinements.
+
 ### Section 11.5 - Perfect Hashing
 
 - Lean source: `CLRSLean/Chapter_11/Section_11_5_Perfect_Hashing.lean`


### PR DESCRIPTION
## Summary

Completes the outstanding ch11 hash-function and open-addressing theorems:

- **Section 11.3 — Theorem 11.5**: the general affine mod-`m` universal hash family `affineHashMod`, with `affineHashMod_isUniversal`, proved via congruent-pair counting lemmas (`count_congruent_gt_le`, `count_congruent_lt_le`, `congruentPair_count_le`).
- **Section 11.4 — Theorem 11.8 (logarithmic form)**: `expectedSuccessfulProbes_le_ln`, refining the harmonic-sum bound to `(1/α)·ln(1/(1-α))` via the free-capacity identity `openLoadFactor_inv_eq` and the integral/telescoping bound `sum_inv_shift_le_log`.
- Updated the `Chapter_11` guide and `docs/proof-map.md` ledger.

## Verification

- `lake build CLRSLean` passes (0 errors).
- `#print axioms` on the headline theorems shows only `propext / Classical.choice / Quot.sound` — no `sorryAx`.
- No `sorry`/`admit` in the changed files.

Note: `scripts/check_repository.py` reports pre-existing ch34 site-navigation gaps in `literate.toml` / `docs/index.md` (e.g. `CNFToCliqueMachine` missing) that originate from main, not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)