### PR TITLE
feat(ch01): migrate Chapter 1 facade to native fourth-edition source

### DIFF
--- a/CLRSLean/Chapter_01.lean
+++ b/CLRSLean/Chapter_01.lean
@@ -1,63 +1,12 @@
-import Mathlib
+import CLRSLean.FourthEdition.Chapter_01
 
 /-!
-# Chapter 1. Algorithms
+# Chapter 1 - Algorithms
 
-This chapter is the doorway.  CLRS introduces what an algorithm is, why
-correctness and efficiency matter, and how to think about algorithm design.
-We do not repeat the original text; instead we show what those ideas look
-like in Lean.
-
-## An algorithm is a function … with a proof
-
-In CLRS-Lean, *algorithm* means two things that live side by side:
-
-1. A Lean function that computes something — the executable part.
-2. A theorem that states what the function guarantees — the proof part.
-
-For example, insertion sort is a pair {lit}`(f, P)` where {lit}`f` sorts a list and
-{lit}`P` says that the result is ordered and permutes the input — see
-Chapter 2 for the real Lean version.
-
-Every section in later chapters follows this pattern: define the computation,
-then prove the claim.
-
-## Why formalize algorithm proofs?
-
-Algorithm textbooks use pseudocode and loop invariants.  Lean can express
-the same invariants as types, and the same inductive reasoning as dependent
-pattern matching.  The gain is **machine-checked certainty**:
-
-* No off-by-one errors in the invariant.
-* No hand-waving about "and so forth" in an induction.
-* The proof object can be inspected, reused, and composed.
-
-The cost is precision: every case must be handled, every inequality justified.
-
-## How to read the rest
-
-Start with the sections that already have strong proof stories:
-
-* Chapter 2: sorting correctness, a runtime bound, and a merge-sort recurrence.
-* Chapter 16: Huffman optimality, the flagship greedy proof.
-* Chapter 23: the MST cut property and Kruskal's induction.
-
-To build and browse the site locally:
-
-* {lit}`lake build` compiles everything.
-* {lit}`lake build :literateHtml` generates this website.
-
-## Conventions
-
-* **0-indexed**: lists and sequences start at 0, for Mathlib compatibility.
-* **Total functions**: partial operations return junk values, not {lit}`Option`.
-* **Unfinished theorem targets**: kept out of imported proof files and recorded
-  as {lit}`partial`, {lit}`blocked-design`, or {lit}`future-work` in the status pages.
-  Each chapter page lists exactly what is missing.
-
-## Repository
-
-[TankTechnology/CLRS-Lean](https://github.com/TankTechnology/CLRS-Lean)
+This legacy guide forwards to the native fourth-edition Chapter 1 guide
+{lit}`CLRSLean.FourthEdition.Chapter_01`.  Chapter 1 is prose-only: it has no
+section directory and no theorem-bearing source, so this forwarding shim carries
+no declarations of its own.
 -/
 
 namespace CLRS

--- a/CLRSLean/FourthEdition/Chapter_01.lean
+++ b/CLRSLean/FourthEdition/Chapter_01.lean
@@ -1,14 +1,70 @@
-import CLRSLean.Chapter_01
+import Mathlib
 
 /-!
 # Chapter 1 — The Role of Algorithms in Computing
 
-This is the canonical CLRS fourth-edition chapter guide during the migration
-period.
+This chapter is the doorway.  CLRS introduces what an algorithm is, why
+correctness and efficiency matter, and how to think about algorithm design.
+We do not repeat the original text; instead we show what those ideas look
+like in Lean.
 
 ## Current source
 
-During the compatibility period this guide imports {lit}`CLRSLean.Chapter_01`. Existing declarations retain their current namespaces until the chapter-by-chapter source migration.
+Native fourth-edition guide.  Chapter 1 is prose-only: it has no section
+directory and no theorem-bearing source, so the expository prose is owned here
+directly.  The legacy import {lit}`CLRSLean.Chapter_01` forwards to this guide
+during the compatibility period.
+
+## An algorithm is a function … with a proof
+
+In CLRS-Lean, *algorithm* means two things that live side by side:
+
+1. A Lean function that computes something — the executable part.
+2. A theorem that states what the function guarantees — the proof part.
+
+For example, insertion sort is a pair {lit}`(f, P)` where {lit}`f` sorts a list and
+{lit}`P` says that the result is ordered and permutes the input — see
+Chapter 2 for the real Lean version.
+
+Every section in later chapters follows this pattern: define the computation,
+then prove the claim.
+
+## Why formalize algorithm proofs?
+
+Algorithm textbooks use pseudocode and loop invariants.  Lean can express
+the same invariants as types, and the same inductive reasoning as dependent
+pattern matching.  The gain is **machine-checked certainty**:
+
+* No off-by-one errors in the invariant.
+* No hand-waving about "and so forth" in an induction.
+* The proof object can be inspected, reused, and composed.
+
+The cost is precision: every case must be handled, every inequality justified.
+
+## How to read the rest
+
+Start with the sections that already have strong proof stories:
+
+* Chapter 2: sorting correctness, a runtime bound, and a merge-sort recurrence.
+* Chapter 16: Huffman optimality, the flagship greedy proof.
+* Chapter 23: the MST cut property and Kruskal's induction.
+
+To build and browse the site locally:
+
+* {lit}`lake build` compiles everything.
+* {lit}`lake build :literateHtml` generates this website.
+
+## Conventions
+
+* **0-indexed**: lists and sequences start at 0, for Mathlib compatibility.
+* **Total functions**: partial operations return junk values, not {lit}`Option`.
+* **Unfinished theorem targets**: kept out of imported proof files and recorded
+  as {lit}`partial`, {lit}`blocked-design`, or {lit}`future-work` in the status pages.
+  Each chapter page lists exactly what is missing.
+
+## Repository
+
+[TankTechnology/CLRS-Lean](https://github.com/TankTechnology/CLRS-Lean)
 
 ## Coverage boundary
 
@@ -17,3 +73,8 @@ The existing expository guide is reused; no theorem target is claimed.
 See {lit}`docs/clrs-fourth-edition-map.csv` for the section-level mapping and
 {lit}`docs/migrations/clrs4.md` for compatibility and deprecation policy.
 -/
+
+namespace CLRS
+namespace Chapter01
+end Chapter01
+end CLRS

--- a/docs/clrs-fourth-edition-map.csv
+++ b/docs/clrs-fourth-edition-map.csv
@@ -1,6 +1,6 @@
 chapter_no,section_no,chapter_title,section_title,migration_state,source_modules,legacy_location,coverage_note
-1,1.1,The Role of Algorithms in Computing,Algorithms,facade,CLRSLean.Chapter_01,CLRS third edition Chapter 1,The current Chapter 1 guide supplies the represented proof interface during the compatibility period.
-1,1.2,The Role of Algorithms in Computing,Algorithms as a technology,facade,CLRSLean.Chapter_01,CLRS third edition Chapter 1,The current Chapter 1 guide supplies the represented proof interface during the compatibility period.
+1,1.1,The Role of Algorithms in Computing,Algorithms,native,CLRSLean.FourthEdition.Chapter_01,CLRS third edition Chapter 1,Native fourth-edition guide: prose-only §1.1 Algorithms (expository, no theorem-bearing source). Legacy CLRSLean.Chapter_01 forwards to it during the compatibility period.
+1,1.2,The Role of Algorithms in Computing,Algorithms as a technology,native,CLRSLean.FourthEdition.Chapter_01,CLRS third edition Chapter 1,Native fourth-edition guide: prose-only §1.2 Algorithms as a technology (expository, no theorem-bearing source). Legacy CLRSLean.Chapter_01 forwards to it during the compatibility period.
 2,2.1,Getting Started,Insertion sort,facade,CLRSLean.Chapter_02,CLRS third edition Chapter 2,The current Chapter 2 guide supplies the represented proof interface during the compatibility period.
 2,2.2,Getting Started,Analyzing algorithms,facade,CLRSLean.Chapter_02,CLRS third edition Chapter 2,The current Chapter 2 guide supplies the represented proof interface during the compatibility period.
 2,2.3,Getting Started,Designing algorithms,facade,CLRSLean.Chapter_02,CLRS third edition Chapter 2,The current Chapter 2 guide supplies the represented proof interface during the compatibility period.


### PR DESCRIPTION
## Summary

Migrate Chapter 1 (*The Role of Algorithms in Computing*) from a compatibility
facade to native fourth-edition source ownership.  Chapter 1 is prose-only: it
has no section directory and no theorem-bearing source, so this is a guide
re-point plus an edition-map flip — the first per-chapter smoke test of the
procedure from `docs/migrations/facade-source-migration-plan.md` (PR #249).

This is a source-location re-homing only, no namespace rename: the 4e chapter
number equals the 3e number, so `CLRS.Chapter01` was already canonical (plan §3).

## Changes

- `CLRSLean/FourthEdition/Chapter_01.lean`: native guide now carries the
  expository prose directly (drops `import CLRSLean.Chapter_01`); "Current
  source" block updated.
- `CLRSLean/Chapter_01.lean`: legacy guide is now a forwarding shim to
  `CLRSLean.FourthEdition.Chapter_01` (compatibility contract preserved).
- `docs/clrs-fourth-edition-map.csv`: rows 1.1/1.2 flip `facade` → `native`
  atomically, `source_modules` → `CLRSLean.FourthEdition.Chapter_01`, coverage
  note records legacy forwarding.

## Acceptance gates

- [x] `CLRSLean.FourthEdition.Chapter_01.lean` carries prose directly; legacy
      import not needed; "Current source" block updated.
- [x] Edition map flipped atomically (facade→native, source_modules, legacy forwarding note).
- [x] `literate.toml` entry/title already consistent (unchanged); `Progress.lean`
      unchanged (progress CSV untouched — plan §8).
- [x] `lake build CLRSLean` clean; `uv run python scripts/check_repository.py` passes;
      `python3 scripts/check_edition_map.py` passes; `python3 scripts/check_status_claims.py`
      passes; no `sorry`/`admit`.

## Note on `Tests/FourthEdition_Compatibility.lean`

This shared compat test currently fails on **main before this change** at line 33
(`CLRS.Chapter11.perfectSearch_iff_mem`: unknown identifier) — a pre-existing
staleness from the §11.5 perfect-hashing promotion to canonical Chapter 11, not
a Ch1 regression.  Chapter 1 itself has no legacy section modules, so no
per-chapter `Chapter_01_Legacy_Imports.lean` is required.  Left untouched here to
keep this PR atomic to Ch1.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)