### PR TITLE
fix(tests): relocate Chapter 11 perfect-hashing check to native facade path

### DIFF
--- a/Tests/FourthEdition_Compatibility.lean
+++ b/Tests/FourthEdition_Compatibility.lean
@@ -1,4 +1,5 @@
 import CLRSLean.OnlineMaterial
+import CLRSLean.FourthEdition.Chapter_11
 import CLRSLean.FourthEdition.Chapter_14
 import CLRSLean.FourthEdition.Chapter_17
 import CLRSLean.FourthEdition.Chapter_19
@@ -19,6 +20,7 @@ supplementary material.
 -/
 
 -- Representative declarations reached through shifted legacy and facade paths.
+#check CLRS.Chapter11.perfectSearch_iff_mem
 #check CLRS.Chapter15.matrixChain_correct
 #check CLRS.Chapter14.IntervalTree.intervalSearch?_spec
 #check CLRS.Chapter21.Forest.singletonForest
@@ -30,7 +32,6 @@ supplementary material.
 #check CLRS.Chapter20.VEBTreeMM.delete_correct
 #check CLRS.Chapter33.orientation_spec
 #check CLRS.Chapter04.maxSubarrayDivideCosted_correct
-#check CLRS.Chapter11.perfectSearch_iff_mem
 #check CLRS.Matroid16.greedy_optimal
 #check CLRS.SchedulingMatroid.minPenaltySchedule_correct
 #check CLRS.Chapter29.Dictionary.simplex_optimal_or_unbounded


### PR DESCRIPTION
## Summary

`Tests/FourthEdition_Compatibility.lean:33` referenced `CLRS.Chapter11.perfectSearch_iff_mem` in the "online/supplementary material collected by `CLRSLean.OnlineMaterial`" block. Chapter 11's perfect-hashing section (§11.5) has since been migrated to native fourth-edition source, so the declaration is no longer reachable through `CLRSLean.OnlineMaterial` and the `#check` failed with `unknownIdentifier`.

## Change

- Add `import CLRSLean.FourthEdition.Chapter_11` (native facade).
- Move the `#check CLRS.Chapter11.perfectSearch_iff_mem` from the OnlineMaterial block to the shifted legacy/facade block.

## Verification

- `lake lean Tests/FourthEdition_Compatibility.lean` compiles with no errors.
- `scripts/check_status_claims.py` → "Status claims are consistent."
- `scripts/check_edition_map.py` → "Fourth-edition map OK".
- `scripts/check_repository.py` → only pre-existing Ch34 `PolyBuilder` site-nav gaps remain (out of scope; no Ch34 changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)