### PR TITLE
fix(ch34): de-duplicate private theorem names for Verso search-index IDs

### DIFF
--- a/CLRSLean/Chapter_34/Section_34_4_NP_Completeness_Proofs/CookLevin/Tableau/StatementCircuits/Semantics.lean
+++ b/CLRSLean/Chapter_34/Section_34_4_NP_Completeness_Proofs/CookLevin/Tableau/StatementCircuits/Semantics.lean
@@ -17,7 +17,7 @@ open _root_.Turing.TM2 _root_.Turing.TM2.Stmt
 
 /-- {lit}`evalBundle` depends on a valid bundle only through its evaluated bits.
 This small bridge is useful after selecting one of two already decoded rows. -/
-private theorem evalBundle_of_evalCfgBits_eq
+private theorem statementEvalBundle_of_evalCfgBits_eq
     {tm : _root_.Turing.FinTM2} {H : Nat}
     (leftBuilder rightBuilder : CircuitBuilder) (inputs : Nat → Bool)
     (left : CfgWires tm H) (hleft : left.ValidIn leftBuilder)
@@ -403,7 +403,7 @@ theorem compileStmt_evalBundle
             some (_root_.Turing.TM2.stepAux
               (branch test whenTrue whenFalse) c.var c.stk)
           rw [_root_.Turing.TM2.stepAux, htest]
-          exact evalBundle_of_evalCfgBits_eq selected.builder falseResult.builder
+          exact statementEvalBundle_of_evalCfgBits_eq selected.builder falseResult.builder
             inputs selected.wires selected.valid falseResult.wires
             falseResult.valid hbits hfalseDecoded
       | true =>
@@ -416,7 +416,7 @@ theorem compileStmt_evalBundle
             some (_root_.Turing.TM2.stepAux
               (branch test whenTrue whenFalse) c.var c.stk)
           rw [_root_.Turing.TM2.stepAux, htest]
-          exact evalBundle_of_evalCfgBits_eq selected.builder falseResult.builder
+          exact statementEvalBundle_of_evalCfgBits_eq selected.builder falseResult.builder
             inputs selected.wires selected.valid trueResult.wires
             (trueResult.valid.mono falseResult.extension) hbits
             htrueDecodedAtFalse

--- a/CLRSLean/Chapter_34/Section_34_4_NP_Completeness_Proofs/CookLevin/Tableau/TransitionCircuits/Dispatch/Semantics.lean
+++ b/CLRSLean/Chapter_34/Section_34_4_NP_Completeness_Proofs/CookLevin/Tableau/TransitionCircuits/Dispatch/Semantics.lean
@@ -40,7 +40,7 @@ def dispatchTarget (tm : _root_.Turing.FinTM2) (c : tm.Cfg) :
         else fallback)
 
 /-- Equal evaluated row bits transport successful complete-row decoding. -/
-private theorem evalBundle_of_evalCfgBits_eq
+private theorem dispatchEvalBundle_of_evalCfgBits_eq
     {tm : _root_.Turing.FinTM2} {H : Nat}
     (leftBuilder rightBuilder : CircuitBuilder) (inputs : Nat → Bool)
     (left : CfgWires tm H) (hleft : left.ValidIn leftBuilder)
@@ -133,7 +133,7 @@ theorem dispatchLabelsList_evalBundle
                 evalCfgBits compiled.builder inputs fallback := by
               rw [selected.eval, hselectorEval, hbit]
               rfl
-            have hdecoded := evalBundle_of_evalCfgBits_eq selected.builder
+            have hdecoded := dispatchEvalBundle_of_evalCfgBits_eq selected.builder
               compiled.builder inputs selected.wires selected.valid fallback
               (hfallback.mono compiled.extension) hbits hfallbackCompiled
             convert hdecoded using 1
@@ -151,7 +151,7 @@ theorem dispatchLabelsList_evalBundle
                 evalCfgBits compiled.builder inputs compiled.wires := by
               rw [selected.eval, hselectorEval, hbit]
               rfl
-            have hdecoded := evalBundle_of_evalCfgBits_eq selected.builder
+            have hdecoded := dispatchEvalBundle_of_evalCfgBits_eq selected.builder
               compiled.builder inputs selected.wires selected.valid
               compiled.wires compiled.valid hbits hcompiled
             convert hdecoded using 1

--- a/CLRSLean/Chapter_34/Section_34_4_NP_Completeness_Proofs/CookLevin/Tableau/TransitionCircuits/Semantics.lean
+++ b/CLRSLean/Chapter_34/Section_34_4_NP_Completeness_Proofs/CookLevin/Tableau/TransitionCircuits/Semantics.lean
@@ -22,7 +22,7 @@ noncomputable section
 /-! ## Canonical complete-row bridges -/
 
 /-- Equal evaluated row bits transport successful complete-row decoding. -/
-private theorem evalBundle_of_evalCfgBits_eq
+private theorem transitionEvalBundle_of_evalCfgBits_eq
     {tm : _root_.Turing.FinTM2} {H : Nat}
     (leftBuilder rightBuilder : CircuitBuilder) (inputs : Nat → Bool)
     (left : CfgWires tm H) (hleft : left.ValidIn leftBuilder)
@@ -120,7 +120,7 @@ theorem transitionCircuit_eval_iff
     have hnarrowedAsNext :
         evalBundle narrowed.builder inputs narrowed.wires narrowed.valid =
           some c' :=
-      evalBundle_of_evalCfgBits_eq narrowed.builder narrowed.builder inputs
+      transitionEvalBundle_of_evalCfgBits_eq narrowed.builder narrowed.builder inputs
         narrowed.wires narrowed.valid next hnextNarrowed hbits
         hnextNarrowedDecoded
     rw [hnarrowedDecoded] at hnarrowedAsNext


### PR DESCRIPTION
## Summary

The cold Pages deployment (run 31875225174) failed at the render step with a Verso search-index error:

```
Duplicate document ID: /CLRSLean/Chapter_34/…/TransitionCircuits/Semantics/#_private___0___CLRS___Chapter34___Turing___CookLevin___evalBundle_of_evalCfgBits_eq
```

Three modules in namespace `CLRS.Chapter34.Turing.CookLevin` each declare a file-local `private theorem evalBundle_of_evalCfgBits_eq` as their first private declaration, so Verso's search index generated the same document ID three times.

## Changes

Rename the three private theorems to unique names and update their uses (no proof content changes):
- `TransitionCircuits/Semantics.lean` → `transitionEvalBundle_of_evalCfgBits_eq`
- `TransitionCircuits/Dispatch/Semantics.lean` → `dispatchEvalBundle_of_evalCfgBits_eq`
- `StatementCircuits/Semantics.lean` → `statementEvalBundle_of_evalCfgBits_eq`

## Verification

- `lake build --old CLRSLean` → Build completed successfully (9392 jobs).
- `python3 scripts/check_repository.py` → Repository checks passed.
- A corrected collision scan over every `private` declaration with a doc comment reports no remaining duplicate (namespace, index, name) triple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)