### PR TITLE
feat(ch20): witness all seven vEB operations in the cost layer

### DIFF
--- a/CLRSLean/Chapter_20.lean
+++ b/CLRSLean/Chapter_20.lean
@@ -204,7 +204,11 @@ wrappers.
   {lit}`CLRS.Chapter20.VEBTreeMM.successorCost_le`,
   {lit}`CLRS.Chapter20.VEBTreeMM.predecessorCost_le`,
   {lit}`CLRS.Chapter20.VEBTreeMM.deleteCost_le`,
-  {lit}`CLRS.Chapter20.VEBTreeMM.deleteDepth_le`, and
+  {lit}`CLRS.Chapter20.VEBTreeMM.deleteDepth_le`,
+  {lit}`CLRS.Chapter20.VEBTreeMM.minimumCost_le_bound`,
+  {lit}`CLRS.Chapter20.VEBTreeMM.maximumCost_le_bound`,
+  {lit}`CLRS.Chapter20.VEBTreeMM.deleteDepth_le_bound`,
+  {lit}`CLRS.Chapter20.VEBTreeMM.veb_all_operations_cost_le`, and
   {lit}`CLRS.Chapter20.VEBTreeMM.veb_all_operations_bigO_loglog_u`.
 
 ## Implementation Boundary

--- a/CLRSLean/Chapter_20/Section_20_3_Recursive_VEB.lean
+++ b/CLRSLean/Chapter_20/Section_20_3_Recursive_VEB.lean
@@ -51,6 +51,13 @@ Main results:
 - Theorem {lit}`VEBTreeMM.veb_all_operations_bigO_loglog_u`: branch-faithful
   costs for the recursive operations are {lit}`O(log log u)`; deletion counts
   both recursive calls when an emptied cluster also updates the summary.
+- Theorems {lit}`VEBTreeMM.minimumCost_le_bound`,
+  {lit}`VEBTreeMM.maximumCost_le_bound`, and
+  {lit}`VEBTreeMM.deleteDepth_le_bound`: per-operation bound wrappers for the
+  cached extrema and the deletion recursion depth.
+- Theorem {lit}`VEBTreeMM.veb_all_operations_cost_le`: all seven recursive
+  operations meet their per-operation cost bounds, each witnessed by the real
+  {lit}`*WithCost` instrumentation.
 
 The recursive cached-min/max model now proves all seven vEB operations correct,
 with constant cached extrema and control-flow-aware O(log log u) bounds for the
@@ -3949,6 +3956,25 @@ theorem deleteCost_le_bound {k : Nat} (v : VEBTreeMM k) (x : Nat)
     (hwf : WellFormed v) : deleteCost x v ≤ deleteCostBound k :=
   deleteCost_le v x hwf
 
+/-- Cached minimum lookup stays within the standard per-level bound. -/
+theorem minimumCost_le_bound {k : Nat} (v : VEBTreeMM k) :
+    (minimumWithCost v).2 ≤ standardOperationCostBound k := by
+  rw [minimumCost_eq_one v]
+  unfold standardOperationCostBound
+  omega
+
+/-- Cached maximum lookup stays within the standard per-level bound. -/
+theorem maximumCost_le_bound {k : Nat} (v : VEBTreeMM k) :
+    (maximumWithCost v).2 ≤ standardOperationCostBound k := by
+  rw [maximumCost_eq_one v]
+  unfold standardOperationCostBound
+  omega
+
+/-- The longest recursive deletion path stays within the standard per-level bound. -/
+theorem deleteDepth_le_bound {k : Nat} (v : VEBTreeMM k) (x : Nat) :
+    deleteDepth x v ≤ standardOperationCostBound k := by
+  simpa [standardOperationCostBound] using deleteDepth_le v x
+
 /-- The standard recursive-operation bound is `O(log log u)`. -/
 theorem standardOperationCostBound_bigO_loglog_u :
     CLRS.Chapter03.isBigO
@@ -3988,6 +4014,34 @@ theorem veb_all_operations_bigO_loglog_u :
         (fun k => (Nat.log 2 (Nat.log 2 (uSize k)) : ℝ)) :=
   ⟨standardOperationCostBound_bigO_loglog_u,
     deleteCostBound_bigO_loglog_u⟩
+
+/--
+**All seven recursive vEB operations meet their per-operation cost bounds.**
+Cached extrema cost one unit; member, insert, successor, and predecessor stay
+within the standard per-level bound; deletion stays within the sequential-work
+bound with recursion depth within the standard bound.  Every leg is witnessed
+by the corresponding {lit}`*Cost`/{lit}`*WithCost` function bound to the real
+operation.  Together with {name}`VEBTreeMM.veb_all_operations_bigO_loglog_u`
+this is the literal "constant or {lit}`O(log log u)`" headline for CLRS
+Section 20.3.
+-/
+theorem veb_all_operations_cost_le {k : Nat} (v : VEBTreeMM k)
+    (hwf : WellFormed v) :
+    (minimumWithCost v).2 ≤ standardOperationCostBound k ∧
+    (maximumWithCost v).2 ≤ standardOperationCostBound k ∧
+    (∀ x, memberCost x v ≤ standardOperationCostBound k) ∧
+    (∀ x, insertCost x v ≤ standardOperationCostBound k) ∧
+    (∀ x, successorCost x v ≤ standardOperationCostBound k) ∧
+    (∀ x, predecessorCost x v ≤ standardOperationCostBound k) ∧
+    (∀ x, deleteCost x v ≤ deleteCostBound k) ∧
+    (∀ x, deleteDepth x v ≤ standardOperationCostBound k) :=
+  ⟨minimumCost_le_bound v, maximumCost_le_bound v,
+    fun x => memberCost_le_bound v x,
+    fun x => insertCost_le_bound v x,
+    fun x => successorCost_le_bound v x,
+    fun x => predecessorCost_le_bound v x,
+    fun x => deleteCost_le_bound v x hwf,
+    fun x => deleteDepth_le_bound v x⟩
 
 /-- Membership after deletion is exactly old membership away from the erased key. -/
 theorem delete_member_iff {k : Nat} (v : VEBTreeMM k) (x y : Nat)

--- a/Tests/Chapter_20_Axioms.lean
+++ b/Tests/Chapter_20_Axioms.lean
@@ -5,3 +5,7 @@ import CLRSLean.Chapter_20
 #print axioms CLRS.Chapter20.VEBTreeMM.predecessor_correct
 #print axioms CLRS.Chapter20.VEBTreeMM.delete_correct
 #print axioms CLRS.Chapter20.VEBTreeMM.veb_all_operations_bigO_loglog_u
+#print axioms CLRS.Chapter20.VEBTreeMM.veb_all_operations_cost_le
+#print axioms CLRS.Chapter20.VEBTreeMM.minimumCost_le_bound
+#print axioms CLRS.Chapter20.VEBTreeMM.maximumCost_le_bound
+#print axioms CLRS.Chapter20.VEBTreeMM.deleteDepth_le_bound

--- a/Tests/Chapter_20_Interface.lean
+++ b/Tests/Chapter_20_Interface.lean
@@ -215,6 +215,10 @@ import CLRSLean.Chapter_20.Section_20_3_Recursive_VEB
 #check CLRS.Chapter20.VEBTreeMM.deleteCost_le
 #check CLRS.Chapter20.VEBTreeMM.deleteDepth
 #check CLRS.Chapter20.VEBTreeMM.deleteDepth_le
+#check CLRS.Chapter20.VEBTreeMM.minimumCost_le_bound
+#check CLRS.Chapter20.VEBTreeMM.maximumCost_le_bound
+#check CLRS.Chapter20.VEBTreeMM.deleteDepth_le_bound
+#check CLRS.Chapter20.VEBTreeMM.veb_all_operations_cost_le
 #check CLRS.Chapter20.VEBTreeMM.veb_all_operations_bigO_loglog_u
 #check CLRS.Chapter20.VEBTreeMM.delete_member_iff
 #check CLRS.Chapter20.VEBTreeMM.delete_member_deleted_false

--- a/docs/chapters/chapter-20.md
+++ b/docs/chapters/chapter-20.md
@@ -164,4 +164,8 @@ timing remain a separate implementation refinement.
 - `CLRS.Chapter20.VEBTreeMM.predecessorCost_le`
 - `CLRS.Chapter20.VEBTreeMM.deleteCost_le`
 - `CLRS.Chapter20.VEBTreeMM.deleteDepth_le`
+- `CLRS.Chapter20.VEBTreeMM.minimumCost_le_bound`
+- `CLRS.Chapter20.VEBTreeMM.maximumCost_le_bound`
+- `CLRS.Chapter20.VEBTreeMM.deleteDepth_le_bound`
+- `CLRS.Chapter20.VEBTreeMM.veb_all_operations_cost_le`
 - `CLRS.Chapter20.VEBTreeMM.veb_all_operations_bigO_loglog_u`

--- a/docs/proof-map.md
+++ b/docs/proof-map.md
@@ -3331,6 +3331,10 @@ operation-trace telescope bounded by the sum of dynamic per-operation budgets.
   - `CLRS.Chapter20.VEBTreeMM.predecessorCost_le`
   - `CLRS.Chapter20.VEBTreeMM.deleteCost_le`
   - `CLRS.Chapter20.VEBTreeMM.deleteDepth_le`
+  - `CLRS.Chapter20.VEBTreeMM.minimumCost_le_bound`
+  - `CLRS.Chapter20.VEBTreeMM.maximumCost_le_bound`
+  - `CLRS.Chapter20.VEBTreeMM.deleteDepth_le_bound`
+  - `CLRS.Chapter20.VEBTreeMM.veb_all_operations_cost_le`
   - `CLRS.Chapter20.VEBTreeMM.veb_all_operations_bigO_loglog_u`
 - Proof pattern: natural-number quotient/remainder arithmetic, bounded
   high/low recomposition, finite-set representation semantics,


### PR DESCRIPTION
Closes #296.

Closes the Ch20 (van Emde Boas) cost-layer tail that the #234 verification queue deferred without running. The recursive §20.3 cost functions were already branch-faithful and axiom-clean on `main`; the audit found one literal gap: the cached-extrema constant cost and the deletion recursion depth were asserted only in prose, and the headline "all operations" theorem stated only the standard + delete big-O legs.

## What was missing and what was proved

- `minimumCost_le_bound` — cached minimum cost `(minimumWithCost v).2` is within `standardOperationCostBound k` (constant extrema inside the `O(log log u)` family).
- `maximumCost_le_bound` — same for the cached maximum.
- `deleteDepth_le_bound` — deletion recursion depth `deleteDepth x v` is within the standard per-level bound.
- `veb_all_operations_cost_le` — a single theorem collecting all seven per-operation cost bounds (minimum, maximum, member, insert, successor, predecessor, delete, plus deletion depth), each leg bound to the real `*WithCost`/`*Cost` code; `veb_all_operations_bigO_loglog_u` remains the `O(log log u)` packaging.

## Verification

- `grep -nE 'sorry|admit|axiom'` over the three Ch20 sources and tests: clean (only `#print axioms` test commands).
- `#print axioms` on the new headline and per-op theorems: only `propext`/`Classical.choice`/`Quot.sound`.
- `Tests/Chapter_20_Interface.lean` and `Tests/Chapter_20_Axioms.lean` extended and passing.
- `python3 scripts/check_repository.py` — OK.
- `lake build CLRSLean` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)