### PR TITLE
chore(ch20): promote vEB to main-proof-complete (ledger tidy)

### DIFF
--- a/CLRSLean/Chapter_20.lean
+++ b/CLRSLean/Chapter_20.lean
@@ -165,7 +165,7 @@ wrappers.
   {lit}`CLRS.Chapter20.VEB.operationDepth_monotone`, and
   {lit}`CLRS.Chapter20.VEB.operationDepth_strict_mono`.
 * 20.3 Recursive vEB structure:
-  {lit}`main-proof-complete-for-correctness`.  The genuine recursive
+  {lit}`main-proof-complete`.  The genuine recursive
   cached-min/max summary/cluster structure over the tower universe
   {lit}`uSize k = 2 ^ (2 ^ k)` proves all seven vEB operations against its
   finite-set semantics.  Cached extrema are constant time, the other recursive

--- a/docs/chapters/chapter-20.md
+++ b/docs/chapters/chapter-20.md
@@ -1,6 +1,6 @@
 # Chapter 20 - van Emde Boas Trees
 
-- Status: `main-proof-complete-for-correctness`
+- Status: `main-proof-complete`
 - Lean entry: `CLRSLean/Chapter_20.lean`
 - Interface test: `Tests/Chapter_20_Interface.lean`
 


### PR DESCRIPTION
## Summary

PR #297 closed the van Emde Boas cost-layer tail — all seven vEB operations were witnessed in the cost layer with O(log log u) bounds and are axiom-clean. Commit #300 (`baa45540`) swept the proof-map section header for **van Emde Boas trees** from `main-proof-complete-for-correctness` to `main-proof-complete`, but missed two stale labels elsewhere:

- `docs/chapters/chapter-20.md` — status line still `main-proof-complete-for-correctness`
- `CLRSLean/Chapter_20.lean` — §20.3 "Recursive vEB structure" bullet still `main-proof-complete-for-correctness`

This PR flips both to `main-proof-complete`, matching the canonical proof-map status.

## Scope note

This is **not** the canonical fourth-edition Chapter 20 (Elementary Graph Algorithms). That chapter's `main-proof-complete-for-correctness` status is still accurate — its O(V+E) BFS/DFS cost layer remains unformalized — and is left untouched. The vEB trees are third-edition Chapter 20, retained as official fourth-edition *online material* and excluded from canonical Chapter 20 counts, so they have no row in `clrs-proof-progress.csv`.

## Verification

- `#print axioms` on `veb_all_operations_cost_le`, `veb_all_operations_bigO_loglog_u`, and the per-operation cost bounds shows only `propext` / `Classical.choice` / `Quot.sound` (no `sorryAx`).
- `lake lean CLRSLean/Chapter_20.lean` — clean (no errors, no `sorry`).
- `check_repository.py`, `check_status_claims.py`, `check_progress_csv.py`, `check_edition_map.py` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)