### PR TITLE
chore(progress): refresh generated progress dashboard

### DIFF
--- a/CLRSLean/Progress.lean
+++ b/CLRSLean/Progress.lean
@@ -34,8 +34,7 @@ every theorem already selected for that chapter is proved.
 
 ## Status Counts
 
-* {lit}`main-proof-complete`: 32 chapters.
-* {lit}`main-proof-complete-for-correctness`: 1 chapter.
+* {lit}`main-proof-complete`: 33 chapters.
 * {lit}`partial`: 1 chapter.
 * {lit}`expository`: 1 chapter.
 
@@ -63,7 +62,7 @@ Ch  Chapter                                                     Status          
 17  17. Augmenting Data Structures                              main-proof-complete                  17.1;17.2;17.3                     79        0
 18  18. B-Trees                                                 main-proof-complete                  18.1;18.2;18.3                    147        0
 19  19. Data Structures for Disjoint Sets                       main-proof-complete                  19.1;19.2;19.3;19.4                84        0
-20  20. Elementary Graph Algorithms                             main-proof-complete-for-correctness  20.1;20.2;20.3;20.4;20.5           47        0
+20  20. Elementary Graph Algorithms                             main-proof-complete                  20.1;20.2;20.3;20.4;20.5           47        0
 21  21. Minimum Spanning Trees                                  main-proof-complete                  21.1;21.2                          52        0
 22  22. Single-Source Shortest Paths                            main-proof-complete                  22.1;22.2;22.3;22.4;22.5           31        0
 23  23. All-Pairs Shortest Paths                                main-proof-complete                  23.1;23.2;23.3                     29        0

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ selected.  Edition-level gaps determine the status and **Edition gaps** column.
 | 17 | Augmenting Data Structures | 🟢 complete | 79 / 79 | — |
 | 18 | B-Trees | 🟢 complete | 147 / 147 | — |
 | 19 | Data Structures for Disjoint Sets | 🟢 complete | 84 / 84 | — |
-| 20 | Elementary Graph Algorithms | 🟢 correctness | 47 / 47 | — |
+| 20 | Elementary Graph Algorithms | 🟢 complete | 47 / 47 | — |
 | 21 | Minimum Spanning Trees | 🟢 complete | 52 / 52 | — |
 | 22 | Single-Source Shortest Paths | 🟢 complete | 31 / 31 | — |
 | 23 | All-Pairs Shortest Paths | 🟢 complete | 29 / 29 | — |


### PR DESCRIPTION
Regenerates `CLRSLean/Progress.lean` and the README progress table from `docs/clrs-proof-progress.csv`.

The ch20 Elementary Graph Algorithms flip to `main-proof-complete` (#304) updated the CSV but not the generated dashboard, failing the `Check repository metadata` gate (#220). This PR restores freshness.